### PR TITLE
itdove/ai-guardian#3: Add CLI command to setup IDE hooks with remote config support

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -306,6 +306,7 @@ class TestIDESetup:
                 'claude': {
                     'name': 'Claude Code',
                     'config_path': str(config_file),
+                    'config_dir_env_var': None,  # Disable env var for test
                     'hooks': {}
                 }
             }
@@ -339,8 +340,14 @@ class TestIDESetup:
                 'claude': {
                     'name': 'Claude Code',
                     'config_path': str(config_file),
+                    'config_dir_env_var': None,  # Disable env var for test
                     'hooks': {
-                        'UserPromptSubmit': [{'new': 'hook'}]
+                        'UserPromptSubmit': [
+                            {
+                                'matcher': '*',
+                                'hooks': [{'type': 'command', 'command': 'new-hook'}]
+                            }
+                        ]
                     }
                 }
             }
@@ -367,6 +374,7 @@ class TestIDESetup:
                 'claude': {
                     'name': 'Claude Code',
                     'config_path': str(config_file),
+                    'config_dir_env_var': None,  # Disable env var for test
                     'hooks': {}
                 }
             }


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
Related to: itdove/ai-guardian#3

## Description
This PR updates the IDE configuration structure in test fixtures to support the new CLI command for setting up IDE hooks with remote configuration support. The changes refactor the test setup to properly validate the IDE hook configuration structure.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install the package in development mode: `pip install -e .`
3. Run the test suite: `pytest tests/test_setup.py -v`
4. Verify all tests pass, particularly those related to IDE hook configuration
5. (Optional) Run the full test suite to ensure no regressions: `pytest`

### Scenarios tested
- IDE configuration structure validation in test fixtures
- Test setup for CLI command with remote config support

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: