### PR TITLE
itdove/ai-guardian#8: Add AI_GUARDIAN_CONFIG_DIR environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,14 +711,25 @@ Configure ai-guardian behavior with environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `AI_GUARDIAN_CONFIG_DIR` | Custom configuration directory location | `~/.config/ai-guardian` (or `$XDG_CONFIG_HOME/ai-guardian`) |
 | `AI_GUARDIAN_IDE_TYPE` | Override IDE auto-detection (`claude` or `cursor`) | Auto-detect |
 | `AI_GUARDIAN_SKILL_CACHE_TTL_HOURS` | Skill directory cache TTL in hours | `24` |
 | `AI_GUARDIAN_REFRESH_INTERVAL_HOURS` | Remote config refresh interval | `12` |
 | `AI_GUARDIAN_EXPIRE_AFTER_HOURS` | Remote config expiration time | `168` (7 days) |
 | `AI_GUARDIAN_PATTERN_TOKEN` | Bearer token for pattern server authentication | None |
 
+**Configuration Directory Priority:**
+1. `AI_GUARDIAN_CONFIG_DIR` (if set) - direct override
+2. `$XDG_CONFIG_HOME/ai-guardian` (if `XDG_CONFIG_HOME` is set)
+3. `~/.config/ai-guardian` - default fallback
+
 **Example:**
 ```bash
+# Use custom config directory
+export AI_GUARDIAN_CONFIG_DIR=/opt/company/ai-guardian
+ai-guardian setup --ide claude
+
+# Other environment variables
 export AI_GUARDIAN_IDE_TYPE=claude
 export AI_GUARDIAN_SKILL_CACHE_TTL_HOURS=48
 ```

--- a/ai-guardian-example.json
+++ b/ai-guardian-example.json
@@ -117,11 +117,13 @@
 
   "_environment_variables": {
     "_comment": "Optional environment variables for configuration:",
+    "AI_GUARDIAN_CONFIG_DIR": "Custom config directory (default: ~/.config/ai-guardian or $XDG_CONFIG_HOME/ai-guardian)",
     "AI_GUARDIAN_IDE_TYPE": "claude|cursor (override auto-detection)",
     "AI_GUARDIAN_SKILL_CACHE_TTL_HOURS": "24 (default skill cache TTL)",
     "AI_GUARDIAN_REFRESH_INTERVAL_HOURS": "12 (remote config refresh)",
     "AI_GUARDIAN_EXPIRE_AFTER_HOURS": "168 (remote config expiration)",
-    "AI_GUARDIAN_PATTERN_TOKEN": "Bearer token for pattern server authentication"
+    "AI_GUARDIAN_PATTERN_TOKEN": "Bearer token for pattern server authentication",
+    "_priority_note": "Config dir priority: AI_GUARDIAN_CONFIG_DIR > XDG_CONFIG_HOME/ai-guardian > ~/.config/ai-guardian"
   },
 
   "_permission_format": {

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -22,6 +22,8 @@ import tempfile
 from enum import Enum
 from pathlib import Path
 
+from ai_guardian.config_utils import get_config_dir
+
 # Import tool policy checker for MCP/Skill permissions
 try:
     from ai_guardian.tool_policy import ToolPolicyChecker
@@ -348,8 +350,8 @@ def _load_pattern_server_config():
     """
     try:
         # Try user global config first
-        config_home = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
-        config_path = Path(config_home) / "ai-guardian" / "ai-guardian.json"
+        config_dir = get_config_dir()
+        config_path = config_dir / "ai-guardian.json"
 
         if not config_path.exists():
             # Try project local config

--- a/src/ai_guardian/config_manager.py
+++ b/src/ai_guardian/config_manager.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from ai_guardian.config_utils import get_config_dir
+
 try:
     import toml
 except ImportError:
@@ -28,9 +30,8 @@ class ConfigManager:
 
     def __init__(self):
         """Initialize configuration manager."""
-        # Use XDG_CONFIG_HOME if set
-        config_home = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
-        self.config_dir = Path(config_home) / "ai-guardian"
+        # Get config directory with priority: AI_GUARDIAN_CONFIG_DIR > XDG_CONFIG_HOME > default
+        self.config_dir = get_config_dir()
         self.installation_config_path = self.config_dir / "config.toml"
         self.user_config_path = self.config_dir / "allowed-tools.toml"
         self.project_config_path = Path.cwd() / ".allowed-tools.toml"

--- a/src/ai_guardian/config_utils.py
+++ b/src/ai_guardian/config_utils.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Configuration utilities for ai-guardian.
+
+Shared utilities for configuration directory resolution.
+"""
+
+import os
+from pathlib import Path
+
+
+def get_config_dir() -> Path:
+    """
+    Get ai-guardian configuration directory.
+
+    Priority order:
+    1. AI_GUARDIAN_CONFIG_DIR (direct override)
+    2. XDG_CONFIG_HOME/ai-guardian (XDG standard)
+    3. ~/.config/ai-guardian (default)
+
+    Returns:
+        Path: Configuration directory path
+
+    Examples:
+        >>> os.environ['AI_GUARDIAN_CONFIG_DIR'] = '/custom/path'
+        >>> get_config_dir()
+        PosixPath('/custom/path')
+
+        >>> del os.environ['AI_GUARDIAN_CONFIG_DIR']
+        >>> os.environ['XDG_CONFIG_HOME'] = '/xdg/config'
+        >>> get_config_dir()
+        PosixPath('/xdg/config/ai-guardian')
+
+        >>> del os.environ['XDG_CONFIG_HOME']
+        >>> get_config_dir()
+        PosixPath('~/.config/ai-guardian').expanduser()
+    """
+    # Priority 1: Check AI_GUARDIAN_CONFIG_DIR environment variable
+    config_dir = os.environ.get("AI_GUARDIAN_CONFIG_DIR")
+    if config_dir:
+        return Path(config_dir).expanduser()
+
+    # Priority 2: Check XDG_CONFIG_HOME
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return Path(config_home) / "ai-guardian"
+
+    # Priority 3: Default fallback
+    return Path("~/.config/ai-guardian").expanduser()

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from ai_guardian.config_utils import get_config_dir
+
 
 class IDESetup:
     """Handle IDE hook setup and configuration."""
@@ -373,8 +375,8 @@ class IDESetup:
         """
         try:
             # Get config path
-            config_home = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
-            config_path = Path(config_home) / "ai-guardian" / "ai-guardian.json"
+            config_dir = get_config_dir()
+            config_path = config_dir / "ai-guardian.json"
 
             # Load existing config or create new
             config = {}

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -18,6 +18,8 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 
+from ai_guardian.config_utils import get_config_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -419,9 +421,9 @@ class ToolPolicyChecker:
         return config, config_path if config else None
 
     def _load_user_config(self) -> Tuple[Optional[Dict], Optional[Path]]:
-        """Load user global configuration from ~/.config/ai-guardian/ai-guardian.json."""
-        config_home = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
-        config_path = Path(config_home) / "ai-guardian" / "ai-guardian.json"
+        """Load user global configuration from ai-guardian config directory."""
+        config_dir = get_config_dir()
+        config_path = config_dir / "ai-guardian.json"
         config = self._load_json_file(config_path, "user global")
         return config, config_path if config else None
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import pytest
 
+from ai_guardian.config_utils import get_config_dir
 from ai_guardian.setup import IDESetup, setup_hooks
 
 
@@ -495,6 +496,147 @@ class TestIDESetup:
             assert success is True
             assert '[DRY RUN]' in message
             assert not config_file.exists()
+
+
+class TestConfigDirEnvironmentVariable:
+    """Test cases for AI_GUARDIAN_CONFIG_DIR environment variable."""
+
+    def test_ai_guardian_config_dir_env_var(self, tmp_path):
+        """Test that AI_GUARDIAN_CONFIG_DIR environment variable is respected."""
+        from ai_guardian.config_manager import ConfigManager
+
+        custom_dir = tmp_path / "custom-config"
+        custom_dir.mkdir()
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(custom_dir)}):
+            config_mgr = ConfigManager()
+            assert config_mgr.config_dir == custom_dir
+
+    def test_ai_guardian_config_dir_takes_priority_over_xdg(self, tmp_path):
+        """Test that AI_GUARDIAN_CONFIG_DIR takes priority over XDG_CONFIG_HOME."""
+        from ai_guardian.config_manager import ConfigManager
+
+        ai_guardian_dir = tmp_path / "ai-guardian-custom"
+        xdg_dir = tmp_path / "xdg-home"
+        ai_guardian_dir.mkdir()
+        xdg_dir.mkdir()
+
+        env = {
+            'AI_GUARDIAN_CONFIG_DIR': str(ai_guardian_dir),
+            'XDG_CONFIG_HOME': str(xdg_dir)
+        }
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            config_mgr = ConfigManager()
+            # Should use AI_GUARDIAN_CONFIG_DIR, not XDG_CONFIG_HOME/ai-guardian
+            assert config_mgr.config_dir == ai_guardian_dir
+            assert config_mgr.config_dir != xdg_dir / "ai-guardian"
+
+    def test_xdg_config_home_fallback(self, tmp_path):
+        """Test XDG_CONFIG_HOME is used when AI_GUARDIAN_CONFIG_DIR is not set."""
+        from ai_guardian.config_manager import ConfigManager
+
+        xdg_dir = tmp_path / "xdg-home"
+        xdg_dir.mkdir()
+
+        # Only set XDG_CONFIG_HOME, not AI_GUARDIAN_CONFIG_DIR
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(xdg_dir)}, clear=True):
+            config_mgr = ConfigManager()
+            assert config_mgr.config_dir == xdg_dir / "ai-guardian"
+
+    def test_default_config_dir_when_no_env_vars(self):
+        """Test default config directory when no environment variables are set."""
+        from ai_guardian.config_manager import ConfigManager
+
+        # Clear both environment variables
+        env_backup = os.environ.copy()
+        try:
+            if 'AI_GUARDIAN_CONFIG_DIR' in os.environ:
+                del os.environ['AI_GUARDIAN_CONFIG_DIR']
+            if 'XDG_CONFIG_HOME' in os.environ:
+                del os.environ['XDG_CONFIG_HOME']
+
+            config_mgr = ConfigManager()
+            expected = Path("~/.config/ai-guardian").expanduser()
+            assert config_mgr.config_dir == expected
+        finally:
+            os.environ.clear()
+            os.environ.update(env_backup)
+
+    def test_config_dir_with_tilde_expansion(self, tmp_path):
+        """Test that tilde in AI_GUARDIAN_CONFIG_DIR is expanded."""
+        from ai_guardian.config_manager import ConfigManager
+
+        # Use a path with tilde (will be expanded)
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': '~/my-ai-guardian'}):
+            config_mgr = ConfigManager()
+            # Should be expanded, not contain literal ~
+            assert '~' not in str(config_mgr.config_dir)
+            assert config_mgr.config_dir == Path('~/my-ai-guardian').expanduser()
+
+    def test_get_config_dir_utility_function(self, tmp_path):
+        """Test the get_config_dir utility function directly."""
+        custom_dir = tmp_path / "test-config"
+        custom_dir.mkdir()
+
+        # Test with AI_GUARDIAN_CONFIG_DIR
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(custom_dir)}):
+            result = get_config_dir()
+            assert result == custom_dir
+
+        # Test with XDG_CONFIG_HOME only
+        xdg_dir = tmp_path / "xdg"
+        xdg_dir.mkdir()
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(xdg_dir)}, clear=True):
+            result = get_config_dir()
+            assert result == xdg_dir / "ai-guardian"
+
+        # Test default (no env vars)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = get_config_dir()
+            assert result == Path("~/.config/ai-guardian").expanduser()
+
+    def test_setup_remote_config_with_custom_config_dir(self, tmp_path):
+        """Test that setup_remote_config respects AI_GUARDIAN_CONFIG_DIR."""
+        setup = IDESetup()
+
+        custom_dir = tmp_path / "custom-ai-guardian"
+        custom_dir.mkdir()
+        config_file = custom_dir / "ai-guardian.json"
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(custom_dir)}):
+            success, message = setup.setup_remote_config('https://example.com/policy.json', dry_run=False)
+
+            assert success is True
+            assert config_file.exists()
+
+            # Verify the URL was added to config
+            with open(config_file) as f:
+                config = json.load(f)
+            assert 'remote_configs' in config
+            assert any('example.com' in str(entry) for entry in config['remote_configs']['urls'])
+
+    def test_tool_policy_uses_custom_config_dir(self, tmp_path):
+        """Test that ToolPolicyChecker respects AI_GUARDIAN_CONFIG_DIR."""
+        from ai_guardian.tool_policy import ToolPolicyChecker
+
+        custom_dir = tmp_path / "custom-config"
+        custom_dir.mkdir()
+
+        # Create a test config file
+        config_file = custom_dir / "ai-guardian.json"
+        test_config = {
+            "builtin_tools": {
+                "deny": ["Bash"],
+                "allow": ["Read"]
+            }
+        }
+        config_file.write_text(json.dumps(test_config))
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(custom_dir)}):
+            checker = ToolPolicyChecker()
+            # Verify it loaded from the custom directory
+            assert checker.config is not None
 
 
 class TestSetupHooks:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- This PR does not need a corresponding Jira item. -->
Related GitHub Issue: https://github.com/itdove/ai-guardian/issues/8

## Description
This PR adds support for the `AI_GUARDIAN_CONFIG_DIR` environment variable, allowing users to specify a custom directory location for AI Guardian configuration files. This enhancement provides greater flexibility in deployment scenarios where configuration files need to be stored in non-default locations.

**Changes include:**
- Added environment variable support in `config_manager.py` to check for `AI_GUARDIAN_CONFIG_DIR`
- Updated `config_utils.py` to handle custom config directory paths
- Modified `setup.py` to support the new configuration discovery mechanism
- Updated `tool_policy.py` to respect the custom config directory setting
- Enhanced `__init__.py` with environment variable handling
- Updated `README.md` with documentation on the new environment variable
- Added test coverage in `test_setup.py` for the new functionality
- Updated `ai-guardian-example.json` with relevant examples

The implementation maintains backward compatibility—when `AI_GUARDIAN_CONFIG_DIR` is not set, the system falls back to default configuration directory behavior.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Export the environment variable: `export AI_GUARDIAN_CONFIG_DIR=/path/to/custom/config`
3. Place a valid configuration file in the specified directory
4. Run the AI Guardian application and verify it loads configuration from the custom directory
5. Unset the environment variable: `unset AI_GUARDIAN_CONFIG_DIR`
6. Run the application again and verify it loads configuration from the default location
7. Run the test suite: `pytest tests/test_setup.py` to verify new test coverage passes

### Scenarios tested
- Configuration loading with `AI_GUARDIAN_CONFIG_DIR` environment variable set to a custom path
- Configuration loading with environment variable unset (default behavior)
- Unit tests for environment variable handling and config directory resolution
- Backward compatibility with existing configuration setups

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed:

This change is backward compatible and introduces an optional environment variable. No configuration changes are required for existing deployments. Deployments that wish to use custom configuration directories can opt-in by setting the `AI_GUARDIAN_CONFIG_DIR` environment variable.