### PR TITLE
itdove/ai-guardian#16: Create release skill to automate release workflow

### DIFF
--- a/.claude/skills/release/EXAMPLE_USAGE.md
+++ b/.claude/skills/release/EXAMPLE_USAGE.md
@@ -1,0 +1,249 @@
+# Release Skill Usage Examples
+
+This document provides step-by-step examples of using the release skill.
+
+## Example 1: Regular Minor Release
+
+**Scenario**: You've added new features to main and want to release v1.3.0.
+
+**Prerequisites**:
+- On main branch
+- All tests passing
+- CHANGELOG.md Unreleased section has content
+
+**Steps**:
+
+```bash
+# In Claude Code, invoke the skill
+/release minor
+```
+
+**What happens**:
+
+1. Skill validates prerequisites
+2. Creates `release-1.3` branch from main
+3. Updates version: `1.2.0-dev` → `1.3.0` in both files
+4. Updates CHANGELOG.md:
+   - Moves Unreleased content to `## [1.3.0] - 2026-04-08`
+   - Updates version links
+5. Creates commit with proper message format
+6. Provides tag creation command:
+   ```bash
+   git tag -a v1.3.0 -m "Release version 1.3.0"
+   git push origin v1.3.0
+   ```
+7. Provides post-release checklist
+
+**Expected output**:
+```
+✓ Prerequisites validated
+✓ Version updated: 1.2.0-dev → 1.3.0
+✓ CHANGELOG.md updated for v1.3.0
+✓ Changes committed to release-1.3 branch
+
+Next steps:
+1. Review the changes
+2. Create tag: git tag -a v1.3.0 -m "Release version 1.3.0"
+3. Push tag: git push origin v1.3.0
+4. Monitor GitHub Actions
+5. Merge back to main after verification
+```
+
+## Example 2: Patch Release
+
+**Scenario**: You need to release v1.2.1 with bug fixes.
+
+```bash
+/release patch
+```
+
+**Result**: Version updated `1.2.0-dev` → `1.2.1`
+
+## Example 3: Hotfix Release
+
+**Scenario**: Critical bug in production v1.2.0 needs immediate fix.
+
+```bash
+/release hotfix v1.2.0
+```
+
+**What happens**:
+
+1. Validates v1.2.0 tag exists
+2. Creates `hotfix-1.2.1` branch from v1.2.0 tag
+3. Waits for you to implement the fix
+4. Updates version: `1.2.0` → `1.2.1`
+5. Updates CHANGELOG.md with hotfix entry
+6. Provides tag and merge-back commands
+
+**Workflow**:
+```
+1. /release hotfix v1.2.0
+2. [Make your bug fix]
+3. [Skill updates version and CHANGELOG]
+4. Tag: git tag -a v1.2.1 -m "Hotfix 1.2.1"
+5. Push: git push origin v1.2.1
+6. Merge to release-1.2: git checkout release-1.2 && git merge hotfix-1.2.1
+7. Cherry-pick to main: git checkout main && git cherry-pick <fix-commit-sha>
+```
+
+## Example 4: TestPyPI Test Release
+
+**Scenario**: You want to test the release process before production.
+
+```bash
+/release test
+```
+
+**What happens**:
+
+1. Creates `release-1.2-test` branch
+2. Updates version: `1.2.0-dev` → `1.2.0-test1`
+3. Creates commit
+4. Creates test tag: `v1.2.0-test1`
+5. Provides TestPyPI verification steps
+
+**After tag push**:
+1. GitHub Actions triggers TestPyPI workflow
+2. Package published to https://test.pypi.org/project/ai-guardian/
+3. Verify installation:
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ \
+     ai-guardian==1.2.0-test1
+   ```
+4. Test functionality
+5. Clean up test branch and tag
+
+## Example 5: Manual Helper Usage
+
+**Get current version**:
+```bash
+python .claude/skills/release/release_helper.py get-version
+# Output:
+# pyproject.toml: 1.2.0-dev
+# __init__.py: 1.2.0-dev
+# Match: True
+```
+
+**Calculate next version**:
+```bash
+python .claude/skills/release/release_helper.py calc-version "1.2.0-dev" minor
+# Output: 1.3.0
+```
+
+**Validate prerequisites**:
+```bash
+python .claude/skills/release/release_helper.py validate --type regular
+# Output: ✓ All prerequisites validated
+```
+
+**Update version (careful!)**:
+```bash
+# Only use this if you know what you're doing
+python .claude/skills/release/release_helper.py update-version "1.2.0"
+```
+
+## Error Handling Examples
+
+### Error: Dirty working directory
+
+**Error message**:
+```
+✗ Validation failed:
+  - Working directory has uncommitted changes
+```
+
+**Solution**: Commit or stash your changes before releasing.
+
+### Error: Version mismatch
+
+**Error message**:
+```
+✗ Validation failed:
+  - Version mismatch: pyproject.toml=1.2.0-dev, __init__.py=1.3.0-dev
+```
+
+**Solution**: Fix the version mismatch manually, then retry.
+
+### Error: Empty CHANGELOG
+
+**Error message**:
+```
+✗ Validation failed:
+  - CHANGELOG.md [Unreleased] section is empty
+```
+
+**Solution**: Add your changes to CHANGELOG.md under the Unreleased section.
+
+### Error: Tests failing
+
+**Error message**:
+```
+✗ Tests failed
+  - 3 tests failing in test_ai_guardian.py
+```
+
+**Solution**: Fix the failing tests before releasing.
+
+## Tips
+
+1. **Always test first**: Use `/release test` to verify the workflow before production
+2. **Check CHANGELOG**: Ensure Unreleased section has meaningful content
+3. **Review commits**: Check the changes before pushing tags
+4. **Monitor CI**: Watch GitHub Actions after pushing tags
+5. **Keep versions in sync**: The skill handles this, but verify after manual edits
+
+## Troubleshooting
+
+**Skill not found**:
+- Check `/Users/dvernier/.claude/skills/release/SKILL.md` exists
+- Restart Claude Code if needed
+
+**Helper script errors**:
+- Verify Python 3.9+ installed
+- Check you're in the ai-guardian repository directory
+
+**Version calculation wrong**:
+- Check current version format matches semantic versioning
+- Remove any invalid suffixes manually
+
+## Advanced Usage
+
+### Custom CHANGELOG date
+
+```bash
+# In skill prompt, specify custom date
+# The helper supports --date flag:
+python .claude/skills/release/release_helper.py update-changelog "1.2.0" --date "2026-12-25"
+```
+
+### Dry-run validation
+
+```bash
+# Check prerequisites without making changes
+python .claude/skills/release/release_helper.py validate --type regular
+```
+
+### Multiple test releases
+
+```bash
+/release test  # Creates v1.2.0-test1
+# If needed, increment manually for second test:
+# v1.2.0-test2, v1.2.0-test3, etc.
+```
+
+## Integration with RELEASING.md
+
+The skill automates steps from RELEASING.md but doesn't replace the documentation.
+Use RELEASING.md for:
+- Understanding the release philosophy
+- Manual recovery procedures
+- GitHub Actions configuration
+- PyPI Trusted Publishing setup
+
+Use `/release` skill for:
+- Day-to-day release operations
+- Reducing human error
+- Faster releases
+- Consistent version management

--- a/.claude/skills/release/README.md
+++ b/.claude/skills/release/README.md
@@ -1,0 +1,149 @@
+# Release Skill
+
+This skill automates the release management workflow for any project using semantic versioning. Works with Python, Node.js, and other project types through automatic version file detection.
+
+## Features
+
+- **Auto-detection**: Automatically finds version files (pyproject.toml, package.json, __init__.py, etc.)
+- **Project-agnostic**: Works with Python, Node.js, and generic projects
+- **Multi-file sync**: Keeps all version files synchronized
+- **Smart configuration**: Saves detected files to `.release-config.json` for future use
+- **Semantic versioning**: Follows semver with -dev and -test suffixes
+- **CHANGELOG automation**: Updates CHANGELOG.md following Keep a Changelog format
+
+## Location
+
+This skill can be placed in:
+- **Project-specific**: `.claude/skills/release/` (version controlled with your project)
+- **Global**: `~/.claude/skills/release/` (available across all projects)
+
+Project-specific installation is recommended for:
+- ✅ Version controlling the skill with your project
+- ✅ Customizing for project-specific workflows
+- ✅ Testing in CI/CD
+- ✅ Sharing with contributors
+
+## Files
+
+- **SKILL.md** - Skill documentation (invoked by Claude Code)
+- **release_helper.py** - Python automation utilities (ai-guardian specific)
+- **README.md** - This file
+- **EXAMPLE_USAGE.md** - Usage examples and troubleshooting
+
+## Usage
+
+In Claude Code, invoke the skill with:
+
+```bash
+/release minor              # Create minor version release (1.1.0 -> 1.2.0)
+/release patch              # Create patch version release (1.1.0 -> 1.1.1)
+/release major              # Create major version release (1.0.0 -> 2.0.0)
+/release hotfix v1.1.0      # Create hotfix from v1.1.0 tag
+/release test               # Create TestPyPI test release
+```
+
+## Helper Script
+
+The `release_helper.py` script can also be used standalone:
+
+```bash
+# Get current version (auto-detects version files on first run)
+python .claude/skills/release/release_helper.py get-version
+# Output:
+# 🔍 Auto-detecting version files...
+#   ✓ Found: pyproject.toml (version: 1.2.0-dev)
+#   ✓ Found: src/myproject/__init__.py (version: 1.2.0-dev)
+# ✓ Saved configuration to .release-config.json
+# Current version: 1.2.0-dev
+
+# Calculate next version
+python .claude/skills/release/release_helper.py calc-version "1.2.0-dev" minor
+# Output: 1.3.0
+
+# Update version in all detected files
+python .claude/skills/release/release_helper.py update-version "1.2.0"
+
+# Update CHANGELOG.md
+python .claude/skills/release/release_helper.py update-changelog "1.2.0" --date "2026-04-08"
+
+# Validate prerequisites
+python .claude/skills/release/release_helper.py validate --type regular
+```
+
+## Testing
+
+Tests are located in the AI Guardian repository:
+
+```bash
+cd /path/to/ai-guardian
+pytest tests/test_release_helper.py -v
+```
+
+## Requirements
+
+- Python 3.9+
+- Access to the AI Guardian repository
+- Git command line tools
+
+## Workflow
+
+When you invoke `/release <type>`, Claude Code will:
+
+1. Load SKILL.md and provide it as context
+2. Follow the documented workflow in SKILL.md
+3. Use release_helper.py to automate version updates
+4. Guide you through git operations
+5. Provide post-release checklist
+
+## Version Management
+
+The skill automatically detects and manages version files in your project:
+
+**Supported patterns**:
+- Python: `pyproject.toml`, `setup.py`, `__init__.py`
+- Node.js: `package.json`
+- Generic: `VERSION`, `version.txt`
+
+**Configuration**: On first use, detected files are saved to `.release-config.json`:
+```json
+{
+  "version_files": [
+    {
+      "path": "pyproject.toml",
+      "pattern": "version = \"{version}\"",
+      "description": "Python project metadata"
+    }
+  ],
+  "changelog": "CHANGELOG.md"
+}
+```
+
+The helper script ensures all configured files are updated atomically, maintaining version consistency.
+
+## Safety Features
+
+- Validates prerequisites before starting
+- Checks versions match between files
+- Verifies CHANGELOG.md has content before release
+- Provides clear error messages
+- Fail-safe: manual recovery instructions
+
+## Documentation
+
+- **SKILL.md** - Complete skill documentation and workflow
+- **.release-config.json** - Auto-generated configuration (can be edited manually)
+- **RELEASING.md** (if available) - Project-specific release procedures
+- **AGENTS.md** (if available) - Project-specific guidelines
+
+## Compatibility
+
+- **Python projects**: pyproject.toml, setup.py, __init__.py
+- **Node.js projects**: package.json
+- **Generic projects**: VERSION, version.txt
+- **Custom patterns**: Edit `.release-config.json` to add your own
+
+## Support
+
+For issues or questions about this skill:
+- Original implementation: https://github.com/itdove/ai-guardian/issues/16
+- Adaptable for any project with version files

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: release
+description: Automate project release workflow with version management, CHANGELOG updates, and git operations
+user-invocable: true
+---
+
+# Release Skill
+
+Automates the release management workflow for any project, following semantic versioning and Keep a Changelog conventions. Works with Python, Node.js, and other project types through automatic version file detection.
+
+## Usage
+
+```bash
+/release minor              # Create minor version release (1.1.0 -> 1.2.0)
+/release patch              # Create patch version release (1.1.0 -> 1.1.1)
+/release major              # Create major version release (1.0.0 -> 2.0.0)
+/release hotfix v1.1.0      # Create hotfix from v1.1.0 tag
+/release test               # Create TestPyPI test release
+```
+
+## Authorization Notice
+
+**IMPORTANT**: This repository uses a fork-based workflow.
+
+- **Maintainers** (@itdove): Can use this skill to create and push releases
+- **Contributors**: Should NOT create or push production tags
+  - Fork the repository instead (see CONTRIBUTING.md)
+  - Submit pull requests with changes
+  - Update CHANGELOG.md in your PR
+  - Maintainers will handle releases
+
+**If you are a contributor (not @itdove):**
+- ✅ You can use `/release test` for local testing
+- ✅ You can use the skill to understand the process
+- ❌ DO NOT push production tags (v1.2.0, etc.)
+- ✅ Let maintainers create releases from your PRs
+
+## Skill Invocation
+
+When invoked with arguments (e.g., `/release minor`), this skill guides you through:
+
+1. **Safety Checks**: Verify prerequisites before starting
+2. **Version Management**: Update version in both required files
+3. **CHANGELOG Management**: Update CHANGELOG.md with proper format
+4. **Git Operations**: Create branches, commits, and tags
+5. **Post-Release Guidance**: Provide checklist for manual steps (maintainers only)
+
+## Release Types
+
+### Regular Release (`/release major|minor|patch`)
+
+**Purpose**: Create a new production release from main branch
+
+**Prerequisites**:
+- All tests pass on main
+- CHANGELOG.md has Unreleased section with changes
+- Main branch is up-to-date
+
+**Steps**:
+1. Verify prerequisites (clean working directory, tests pass, CHANGELOG updated)
+2. Create release branch (e.g., `release-1.2`)
+3. Determine new version based on release type
+4. Update version in both files (remove `-dev` suffix)
+5. Update CHANGELOG.md (move Unreleased to version section with date)
+6. Commit changes with proper commit message format
+7. Provide instructions for tagging and verification
+8. Provide post-release checklist
+
+### Hotfix Release (`/release hotfix <tag>`)
+
+**Purpose**: Create a critical bug fix for an existing release
+
+**Prerequisites**:
+- Valid release tag exists (e.g., v1.0.0)
+- Bug fix is truly critical
+
+**Steps**:
+1. Verify tag exists
+2. Create hotfix branch from the specified tag
+3. Guide through bug fix implementation
+4. Calculate hotfix version (increment patch)
+5. Update version in both files
+6. Update CHANGELOG.md with hotfix entry
+7. Provide instructions for tagging
+8. Provide merge-back guidance
+
+### Test Release (`/release test`)
+
+**Purpose**: Test release process with TestPyPI before production
+
+**Prerequisites**:
+- TestPyPI account configured
+- GitHub Actions workflow set up
+
+**Steps**:
+1. Create test release branch
+2. Calculate test version (add `-test` suffix)
+3. Update version in both files
+4. Create test tag (v*-test* pattern)
+5. Provide TestPyPI verification steps
+6. Provide cleanup instructions
+
+## Version Management
+
+### Auto-Detection
+
+On first use, the skill automatically detects version files in your project by scanning for common patterns:
+
+**Python projects**:
+- `pyproject.toml`: `version = "X.Y.Z"`
+- `setup.py`: `version="X.Y.Z"`
+- `__init__.py`: `__version__ = "X.Y.Z"`
+
+**Node.js projects**:
+- `package.json`: `"version": "X.Y.Z"`
+
+**Generic projects**:
+- `VERSION` file: `X.Y.Z`
+- `version.txt`: `X.Y.Z`
+
+The detected configuration is saved to `.release-config.json` and can be edited manually if needed.
+
+**CRITICAL**: All detected version files MUST be kept in sync. The skill automatically updates all configured files together.
+
+**Version Format**:
+- Production: `"1.0.0"` (semantic versioning)
+- Development: `"1.1.0-dev"` (on main branch)
+- Test: `"1.2.0-test1"` (for TestPyPI testing)
+
+**Version Transitions**:
+- Regular release: `1.1.0-dev` → `1.2.0` (remove -dev)
+- Hotfix: `1.1.0` → `1.1.1` (increment patch)
+- Test: `1.2.0-dev` → `1.2.0-test1` (replace -dev with -test1)
+- Post-release: `1.2.0` → `1.3.0-dev` (increment minor, add -dev)
+
+## CHANGELOG.md Format
+
+**Location**: Project root directory (auto-detected as `CHANGELOG.md`)
+
+**Format**: Keep a Changelog format (https://keepachangelog.com/)
+
+**Structure**:
+```markdown
+## [Unreleased]
+
+### Added
+- New features
+
+### Changed
+- Changes to existing functionality
+
+### Fixed
+- Bug fixes
+
+## [1.2.0] - 2026-04-08
+
+### Added
+- Feature X
+- Feature Y
+
+[Unreleased]: https://github.com/owner/repo/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/owner/repo/releases/tag/v1.2.0
+```
+
+**When updating for release**:
+1. Move all `[Unreleased]` content to new version section
+2. Add release date in YYYY-MM-DD format
+3. Update comparison links at bottom
+4. Create new empty `[Unreleased]` section
+
+## Commit Message Format
+
+Follow project conventions:
+
+```
+<type>: <subject>
+
+<body>
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+**Types**:
+- `chore:` - Version bumps, release preparation
+- `docs:` - CHANGELOG updates
+- `fix:` - Hotfix bug fixes
+- `feat:` - New features (rare in release commits)
+
+**Always use HEREDOC** for commit messages to ensure proper formatting:
+```bash
+git commit -m "$(cat <<'EOF'
+chore: bump version to 2.2.0 for release
+
+Prepare for v2.2.0 release:
+- Update version in pyproject.toml
+- Update version in devflow/__init__.py
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Safety Checks
+
+**Before starting any release**:
+1. ✅ Verify git status is clean (no uncommitted changes)
+2. ✅ Verify on correct branch (main for regular, tag for hotfix)
+3. ✅ Verify tests pass: `pytest`
+4. ✅ Verify CHANGELOG.md has Unreleased section (regular releases only)
+5. ✅ Verify versions match between files
+
+**Error Handling**:
+- Dirty working directory → Abort, ask user to commit/stash changes
+- Tests failing → Abort, ask user to fix tests first
+- Wrong branch → Abort, guide to correct branch
+- Missing CHANGELOG updates → Abort, ask user to update CHANGELOG
+
+## Git Operations
+
+**Branch Naming**:
+- Regular release: `release-X.Y` (e.g., `release-2.2`)
+- Hotfix: `hotfix-X.Y.Z` (e.g., `hotfix-2.1.1`)
+- Test release: `release-X.Y-test` (e.g., `release-2.2-test`)
+
+**Tag Naming**:
+- Production: `vX.Y.Z` (e.g., `v2.2.0`)
+- Test: `vX.Y.Z-testN` (e.g., `v2.2.0-test1`)
+
+**Important**:
+- DO NOT push tags automatically - provide command for user to review and push
+- DO NOT run destructive operations without confirmation
+- DO provide clear instructions for manual steps
+
+## Post-Release Checklist
+
+**⚠️ MAINTAINERS ONLY** - Check project's RELEASING.md or CONTRIBUTING.md for authorized release managers.
+
+**Before pushing tag:**
+- [ ] Confirm you are authorized to create releases
+- [ ] Review all changes on the release branch
+- [ ] Verify tests pass locally
+- [ ] Verify version is correct in all configured files
+
+**After creating release tag:**
+1. [ ] Push tag: `git push origin vX.Y.Z`
+2. [ ] Monitor CI/CD pipeline (GitHub Actions, GitLab CI, etc.)
+3. [ ] Verify package publication (PyPI, npm, etc.)
+4. [ ] Verify release notes created
+5. [ ] Test installation from package registry
+6. [ ] Merge release branch back to main
+7. [ ] Bump version to next dev cycle (X.Y+1.0-dev)
+8. [ ] Push main branch
+9. [ ] (Hotfix only) Cherry-pick fix to main
+
+**If you are NOT authorized:**
+- ❌ DO NOT push the tag
+- ✅ Create PR with the release branch
+- ✅ Notify maintainers that release is ready
+- ✅ Provide the tag command in PR description
+
+## Workflow Examples
+
+### Regular Minor Release
+
+```bash
+/release minor
+
+# Skill will:
+# 1. Auto-detect version files (first run only)
+# 2. Verify prerequisites
+# 3. Create release-1.2 branch
+# 4. Update version 1.1.0-dev → 1.2.0 in all detected files
+# 5. Update CHANGELOG.md for v1.2.0
+# 6. Commit changes
+# 7. Provide tag creation command: git tag -a v1.2.0 -m "..."
+# 8. Provide post-release instructions
+```
+
+### Hotfix Release
+
+```bash
+/release hotfix v1.1.0
+
+# Skill will:
+# 1. Verify v1.1.0 tag exists
+# 2. Create hotfix-1.1.1 branch from v1.1.0
+# 3. Wait for user to implement fix
+# 4. Update version to 1.1.1 in all configured files
+# 5. Update CHANGELOG.md for v1.1.1
+# 6. Commit changes
+# 7. Provide tag creation and merge-back commands
+```
+
+### Test Release
+
+```bash
+/release test
+
+# Skill will:
+# 1. Create release-1.2-test branch
+# 2. Update version 1.2.0-dev → 1.2.0-test1 in all configured files
+# 3. Commit changes
+# 4. Create test tag v1.2.0-test1
+# 5. Provide test verification steps
+# 6. Provide cleanup commands
+```
+
+## Implementation Guidelines
+
+**When user invokes this skill**:
+
+1. **Auto-detect version files** (first run only): Scan for common version file patterns
+2. **Parse arguments**: Determine release type (major/minor/patch/hotfix/test)
+3. **Run safety checks**: Verify prerequisites before proceeding
+4. **Calculate new version**: Based on current version and release type
+5. **Update version files**: Edit all detected version files atomically
+6. **Update CHANGELOG**: Move Unreleased to version section with date
+7. **Create commits**: Use proper commit message format
+8. **Provide guidance**: Show commands for tagging and next steps
+9. **Validate**: Ensure versions match between all files
+
+**Error Recovery**:
+- If any step fails, provide clear error message and recovery steps
+- Never leave repository in inconsistent state
+- If versions are out of sync, stop and report the issue
+- If no version files detected, provide instructions for manual configuration
+
+## Testing Strategy
+
+**Before using this skill for production releases**:
+
+1. **Test version detection**:
+   ```bash
+   python .claude/skills/release/release_helper.py get-version
+   # Verify all version files detected correctly
+   ```
+
+2. **Test with test release first**:
+   ```bash
+   /release test
+   # Verify workflow works end-to-end
+   ```
+
+3. **Verify version updates**:
+   - Check all detected files updated correctly
+   - Verify versions match across all files
+   - Verify -dev suffix handling
+
+4. **Verify CHANGELOG updates**:
+   - Unreleased section moved correctly
+   - Date added in correct format
+   - Comparison links generated
+
+5. **Verify safety checks**:
+   - Test with uncommitted changes (should abort)
+   - Test on wrong branch (should abort)
+   - Test with missing CHANGELOG updates (should abort)
+
+## References
+
+- **RELEASING.md** - Project-specific release procedures (if available)
+- **CONTRIBUTING.md** - Project contribution guidelines (if available)
+- **.release-config.json** - Auto-generated version file configuration
+- **CHANGELOG.md** - Project changelog (Keep a Changelog format)
+- **release_helper.py** - Python automation script
+- **.github/workflows/** - CI/CD workflows (if applicable)
+
+## Benefits
+
+- ✅ **Project-agnostic**: Works with Python, Node.js, and generic projects
+- ✅ **Auto-detection**: Automatically finds and configures version files
+- ✅ Reduces human error in release process
+- ✅ Ensures consistency with documented procedures
+- ✅ Saves time by automating repetitive tasks
+- ✅ Provides guardrails and safety checks
+- ✅ Maintains high quality release standards
+- ✅ Keeps version files in sync automatically
+- ✅ Enforces fork-based workflow authorization (when configured)
+
+## Configuration
+
+The skill creates `.release-config.json` on first use. You can manually edit this file to:
+
+- Add custom version file patterns
+- Specify different CHANGELOG location
+- Adjust version file descriptions
+
+Example configuration:
+```json
+{
+  "version_files": [
+    {
+      "path": "pyproject.toml",
+      "pattern": "version = \"{version}\"",
+      "description": "Python project metadata"
+    },
+    {
+      "path": "src/myproject/__init__.py",
+      "pattern": "__version__ = \"{version}\"",
+      "description": "Python package version"
+    }
+  ],
+  "changelog": "CHANGELOG.md"
+}
+```
+
+## Future Enhancements
+
+- Automatic CHANGELOG.md generation from git commits
+- Integration with GitHub API for automated PR creation
+- Automated package registry verification
+- Support for monorepo version management

--- a/.claude/skills/release/release_helper.py
+++ b/.claude/skills/release/release_helper.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""
+Project-Agnostic Release Helper
+
+This module provides automation utilities for release management:
+- Auto-detects version files in your project
+- Supports multiple project types (Python, Node.js, etc.)
+- Updates CHANGELOG.md with proper formatting
+- Validates version consistency
+- Calculates next version based on release type
+
+Supports optional .release-config.json for custom configurations.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple, Optional, List, Dict, Any
+
+
+class VersionFile:
+    """Represents a file containing version information."""
+
+    def __init__(self, path: Path, pattern: str, description: str = ""):
+        self.path = path
+        self.pattern = pattern  # Regex pattern with {version} placeholder
+        self.description = description
+
+    def read_version(self) -> Optional[str]:
+        """Read version from this file."""
+        try:
+            if not self.path.exists():
+                return None
+
+            content = self.path.read_text()
+            # Convert pattern to regex
+            regex_pattern = self.pattern.replace("{version}", r"([^\"']+)")
+            match = re.search(regex_pattern, content, re.MULTILINE)
+            return match.group(1) if match else None
+        except Exception as e:
+            print(f"Error reading {self.path}: {e}", file=sys.stderr)
+            return None
+
+    def write_version(self, new_version: str) -> bool:
+        """Write new version to this file."""
+        try:
+            if not self.path.exists():
+                print(f"Warning: {self.path} does not exist", file=sys.stderr)
+                return False
+
+            content = self.path.read_text()
+            # Convert pattern to regex
+            regex_pattern = self.pattern.replace("{version}", r"[^\"']+")
+            new_content = self.pattern.replace("{version}", new_version)
+
+            updated = re.sub(
+                regex_pattern,
+                new_content,
+                content,
+                count=1,
+                flags=re.MULTILINE
+            )
+
+            self.path.write_text(updated)
+            return True
+        except Exception as e:
+            print(f"Error writing {self.path}: {e}", file=sys.stderr)
+            return False
+
+
+class ReleaseHelper:
+    """Project-agnostic release helper with auto-detection."""
+
+    # Common version file patterns
+    VERSION_PATTERNS = [
+        # Python patterns
+        {
+            "glob": "**/pyproject.toml",
+            "pattern": 'version = "{version}"',
+            "description": "Python project metadata (pyproject.toml)"
+        },
+        {
+            "glob": "**/setup.py",
+            "pattern": 'version="{version}"',
+            "description": "Python setup.py"
+        },
+        {
+            "glob": "**/__init__.py",
+            "pattern": '__version__ = "{version}"',
+            "description": "Python package __init__.py"
+        },
+        {
+            "glob": "**/__version__.py",
+            "pattern": '__version__ = "{version}"',
+            "description": "Python __version__.py"
+        },
+        # Node.js patterns
+        {
+            "glob": "**/package.json",
+            "pattern": '"version": "{version}"',
+            "description": "Node.js package.json"
+        },
+        # Generic patterns
+        {
+            "glob": "**/VERSION",
+            "pattern": '{version}',
+            "description": "VERSION file"
+        },
+    ]
+
+    def __init__(self, repo_path: str = ".", config_file: str = ".release-config.json"):
+        """
+        Initialize ReleaseHelper with auto-detection.
+
+        Args:
+            repo_path: Path to repository root
+            config_file: Name of config file (default: .release-config.json)
+        """
+        self.repo_path = Path(repo_path).resolve()
+        self.config_path = self.repo_path / config_file
+        self.changelog_path = self.repo_path / "CHANGELOG.md"
+
+        # Load or detect configuration
+        self.config = self._load_or_detect_config()
+        self.version_files = self._create_version_files()
+
+    def _load_or_detect_config(self) -> Dict[str, Any]:
+        """Load config from file or auto-detect."""
+        # Try to load existing config
+        if self.config_path.exists():
+            try:
+                with open(self.config_path, 'r') as f:
+                    config = json.load(f)
+                print(f"✓ Loaded configuration from {self.config_path.name}", file=sys.stderr)
+                return config
+            except Exception as e:
+                print(f"Warning: Could not load {self.config_path}: {e}", file=sys.stderr)
+
+        # Auto-detect
+        print("🔍 Auto-detecting version files...", file=sys.stderr)
+        detected = self._auto_detect_version_files()
+
+        if not detected:
+            print("⚠️  No version files auto-detected. Please create .release-config.json", file=sys.stderr)
+            return {"version_files": [], "changelog": "CHANGELOG.md"}
+
+        config = {
+            "version_files": detected,
+            "changelog": "CHANGELOG.md",
+            "_comment": "Auto-generated by release helper. Edit as needed."
+        }
+
+        # Save detected config
+        self._save_config(config)
+
+        return config
+
+    def _auto_detect_version_files(self) -> List[Dict[str, str]]:
+        """Auto-detect version files in the project."""
+        detected = []
+
+        for pattern_def in self.VERSION_PATTERNS:
+            # Search for files matching this pattern
+            matches = list(self.repo_path.glob(pattern_def["glob"]))
+
+            for file_path in matches:
+                # Make path relative to repo root
+                try:
+                    rel_path = file_path.relative_to(self.repo_path)
+                except ValueError:
+                    continue
+
+                # Skip if in excluded directories
+                if any(part.startswith('.') for part in rel_path.parts[:-1]):
+                    continue  # Skip hidden directories
+                if any(part in ['node_modules', 'venv', '__pycache__', 'dist', 'build']
+                       for part in rel_path.parts):
+                    continue  # Skip common excluded dirs
+
+                # Check if this file actually contains a version
+                test_file = VersionFile(file_path, pattern_def["pattern"])
+                version = test_file.read_version()
+
+                if version:
+                    detected.append({
+                        "path": str(rel_path),
+                        "pattern": pattern_def["pattern"],
+                        "description": pattern_def["description"],
+                        "detected_version": version
+                    })
+                    print(f"  ✓ Found: {rel_path} (version: {version})", file=sys.stderr)
+
+        return detected
+
+    def _save_config(self, config: Dict[str, Any]) -> bool:
+        """Save configuration to .release-config.json."""
+        try:
+            with open(self.config_path, 'w') as f:
+                json.dump(config, f, indent=2)
+            print(f"✓ Saved configuration to {self.config_path.name}", file=sys.stderr)
+            return True
+        except Exception as e:
+            print(f"Warning: Could not save config: {e}", file=sys.stderr)
+            return False
+
+    def _create_version_files(self) -> List[VersionFile]:
+        """Create VersionFile objects from config."""
+        version_files = []
+
+        for vf_config in self.config.get("version_files", []):
+            path = self.repo_path / vf_config["path"]
+            pattern = vf_config["pattern"]
+            description = vf_config.get("description", "")
+
+            version_files.append(VersionFile(path, pattern, description))
+
+        return version_files
+
+    def get_current_version(self) -> Tuple[Optional[str], bool]:
+        """
+        Get current version from all configured files.
+
+        Returns:
+            Tuple of (version, all_match)
+            - version: The version string if all match, or None
+            - all_match: True if all files have the same version
+        """
+        if not self.version_files:
+            print("Error: No version files configured", file=sys.stderr)
+            return None, False
+
+        versions = {}
+        for vf in self.version_files:
+            ver = vf.read_version()
+            if ver:
+                versions[str(vf.path.relative_to(self.repo_path))] = ver
+
+        if not versions:
+            return None, False
+
+        unique_versions = set(versions.values())
+        all_match = len(unique_versions) == 1
+        current_version = list(unique_versions)[0] if all_match else None
+
+        if not all_match:
+            print("⚠️  Version mismatch detected:", file=sys.stderr)
+            for file, ver in versions.items():
+                print(f"  {file}: {ver}", file=sys.stderr)
+
+        return current_version, all_match
+
+    def update_version(self, new_version: str) -> bool:
+        """
+        Update version in all configured files.
+
+        Args:
+            new_version: The new version string (e.g., "1.2.0")
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.version_files:
+            print("Error: No version files configured", file=sys.stderr)
+            return False
+
+        try:
+            # Update all files
+            for vf in self.version_files:
+                if not vf.write_version(new_version):
+                    return False
+
+            # Verify update
+            version, all_match = self.get_current_version()
+            if version == new_version and all_match:
+                print(f"✓ Version updated to {new_version} in all files", file=sys.stderr)
+                return True
+            else:
+                print(f"Error: Version update verification failed", file=sys.stderr)
+                return False
+
+        except Exception as e:
+            print(f"Error updating version: {e}", file=sys.stderr)
+            return False
+
+    def calculate_next_version(self, current_version: str, release_type: str) -> Optional[str]:
+        """
+        Calculate next version based on release type.
+
+        Args:
+            current_version: Current version (e.g., "1.1.0-dev")
+            release_type: One of "major", "minor", "patch", "test"
+
+        Returns:
+            Next version string or None if invalid
+        """
+        # Remove -dev or -test* suffix
+        base_version = re.sub(r'-dev|-test\d*', '', current_version)
+
+        # Parse semantic version
+        match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', base_version)
+        if not match:
+            print(f"Error: Invalid version format: {base_version}", file=sys.stderr)
+            return None
+
+        major, minor, patch = map(int, match.groups())
+
+        if release_type == "major":
+            return f"{major + 1}.0.0"
+        elif release_type == "minor":
+            return f"{major}.{minor + 1}.0"
+        elif release_type == "patch":
+            return f"{major}.{minor}.{patch + 1}"
+        elif release_type == "test":
+            return f"{major}.{minor}.{patch}-test1"
+        else:
+            print(f"Error: Invalid release type: {release_type}", file=sys.stderr)
+            return None
+
+    def update_changelog(self, version: str, date: Optional[str] = None) -> bool:
+        """
+        Update CHANGELOG.md by moving Unreleased section to new version.
+
+        Args:
+            version: New version (e.g., "1.2.0")
+            date: Release date in YYYY-MM-DD format (defaults to today)
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if date is None:
+            date = datetime.now().strftime("%Y-%m-%d")
+
+        changelog_file = self.repo_path / self.config.get("changelog", "CHANGELOG.md")
+
+        if not changelog_file.exists():
+            print(f"Warning: {changelog_file.name} not found", file=sys.stderr)
+            return False
+
+        try:
+            content = changelog_file.read_text()
+
+            # Check if Unreleased section exists
+            if "## [Unreleased]" not in content:
+                print("Warning: No [Unreleased] section found in CHANGELOG", file=sys.stderr)
+                return False
+
+            # Find the Unreleased section content
+            unreleased_pattern = r'## \[Unreleased\]\s*(.*?)(?=## \[|$)'
+            unreleased_match = re.search(unreleased_pattern, content, re.DOTALL)
+
+            if not unreleased_match:
+                print("Warning: Could not parse Unreleased section", file=sys.stderr)
+                return False
+
+            unreleased_content = unreleased_match.group(1).strip()
+
+            # Check if there's actual content
+            if not unreleased_content or unreleased_content.isspace():
+                print("Warning: Unreleased section is empty", file=sys.stderr)
+                return False
+
+            # Create new version section
+            version_section = f"## [{version}] - {date}\n\n{unreleased_content}\n\n"
+
+            # Replace Unreleased section with new empty one + version section
+            new_content = re.sub(
+                r'## \[Unreleased\]\s*.*?(?=## \[|$)',
+                f"## [Unreleased]\n\n{version_section}",
+                content,
+                count=1,
+                flags=re.DOTALL
+            )
+
+            # Update version links at the bottom (if they exist)
+            repo_url_match = re.search(
+                r'\[Unreleased\]: (https://github\.com/[^/]+/[^/]+)/compare/v([^.]+\.[^.]+\.[^.]+)\.\.\.HEAD',
+                new_content
+            )
+
+            if repo_url_match:
+                repo_url = repo_url_match.group(1)
+
+                # Update Unreleased link to compare from new version
+                new_content = re.sub(
+                    r'\[Unreleased\]: .*?\n',
+                    f'[Unreleased]: {repo_url}/compare/v{version}...HEAD\n',
+                    new_content,
+                    count=1
+                )
+
+                # Add new version link
+                new_version_link = f'[{version}]: {repo_url}/releases/tag/v{version}\n'
+                new_content = re.sub(
+                    r'(\[Unreleased\]: .*?\n)',
+                    f'\\1{new_version_link}',
+                    new_content,
+                    count=1
+                )
+
+            changelog_file.write_text(new_content)
+            print(f"✓ Updated CHANGELOG.md for version {version}", file=sys.stderr)
+            return True
+
+        except Exception as e:
+            print(f"Error updating CHANGELOG: {e}", file=sys.stderr)
+            return False
+
+    def validate_prerequisites(self, release_type: str = "regular") -> Tuple[bool, List[str]]:
+        """
+        Validate prerequisites for a release.
+
+        Args:
+            release_type: "regular", "hotfix", or "test"
+
+        Returns:
+            Tuple of (all_valid, list_of_errors)
+        """
+        errors = []
+
+        # Check version files exist
+        if not self.version_files:
+            errors.append("No version files configured")
+        else:
+            for vf in self.version_files:
+                if not vf.path.exists():
+                    errors.append(f"{vf.path.relative_to(self.repo_path)} not found")
+
+        # Check CHANGELOG exists
+        changelog_file = self.repo_path / self.config.get("changelog", "CHANGELOG.md")
+        if not changelog_file.exists():
+            errors.append(f"{changelog_file.name} not found")
+
+        if errors:
+            return False, errors
+
+        # Check versions match
+        version, all_match = self.get_current_version()
+        if not all_match:
+            errors.append("Version mismatch between files")
+
+        # For regular releases, check CHANGELOG has content
+        if release_type == "regular":
+            try:
+                content = changelog_file.read_text()
+                if "## [Unreleased]" not in content:
+                    errors.append("CHANGELOG missing [Unreleased] section")
+                else:
+                    # Check if Unreleased has content
+                    unreleased_pattern = r'## \[Unreleased\]\s*(.*?)(?=## \[|$)'
+                    match = re.search(unreleased_pattern, content, re.DOTALL)
+                    if match:
+                        unreleased_content = match.group(1).strip()
+                        if not unreleased_content or unreleased_content.isspace():
+                            errors.append("CHANGELOG [Unreleased] section is empty")
+            except Exception as e:
+                errors.append(f"Error reading CHANGELOG: {e}")
+
+        return len(errors) == 0, errors
+
+    def show_config(self):
+        """Display current configuration."""
+        print("\n📋 Current Configuration", file=sys.stderr)
+        print("="*60, file=sys.stderr)
+        print(f"Config file: {self.config_path.name}", file=sys.stderr)
+        print(f"Repository: {self.repo_path}", file=sys.stderr)
+        print(f"\nVersion files ({len(self.version_files)}):", file=sys.stderr)
+
+        for vf in self.version_files:
+            rel_path = vf.path.relative_to(self.repo_path)
+            version = vf.read_version()
+            print(f"  • {rel_path}", file=sys.stderr)
+            print(f"    Pattern: {vf.pattern}", file=sys.stderr)
+            print(f"    Current: {version}", file=sys.stderr)
+            if vf.description:
+                print(f"    ({vf.description})", file=sys.stderr)
+
+        print(f"\nChangelog: {self.config.get('changelog', 'CHANGELOG.md')}", file=sys.stderr)
+        print("="*60, file=sys.stderr)
+
+
+def main():
+    """CLI interface for release helper."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Project-agnostic release helper with auto-detection",
+        epilog="Auto-detects version files or uses .release-config.json"
+    )
+    parser.add_argument("--repo", default=".", help="Repository path (default: current directory)")
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # Show config
+    subparsers.add_parser("show-config", help="Show current configuration")
+
+    # Get version
+    subparsers.add_parser("get-version", help="Get current version from all files")
+
+    # Update version
+    update_parser = subparsers.add_parser("update-version", help="Update version in all files")
+    update_parser.add_argument("version", help="New version (e.g., 1.2.0)")
+
+    # Calculate next version
+    calc_parser = subparsers.add_parser("calc-version", help="Calculate next version")
+    calc_parser.add_argument("current", help="Current version")
+    calc_parser.add_argument("type", choices=["major", "minor", "patch", "test"], help="Release type")
+
+    # Update changelog
+    changelog_parser = subparsers.add_parser("update-changelog", help="Update CHANGELOG.md")
+    changelog_parser.add_argument("version", help="Version to release")
+    changelog_parser.add_argument("--date", help="Release date (YYYY-MM-DD, default: today)")
+
+    # Validate
+    validate_parser = subparsers.add_parser("validate", help="Validate prerequisites")
+    validate_parser.add_argument("--type", default="regular", choices=["regular", "hotfix", "test"],
+                                 help="Release type")
+
+    # Re-detect
+    subparsers.add_parser("detect", help="Re-run auto-detection and update config")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    helper = ReleaseHelper(args.repo)
+
+    if args.command == "show-config":
+        helper.show_config()
+        sys.exit(0)
+
+    elif args.command == "get-version":
+        version, all_match = helper.get_current_version()
+        if version:
+            print(f"Current version: {version}")
+            print(f"All files match: {all_match}")
+            sys.exit(0 if all_match else 1)
+        else:
+            print("Could not determine version", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == "update-version":
+        success = helper.update_version(args.version)
+        sys.exit(0 if success else 1)
+
+    elif args.command == "calc-version":
+        next_version = helper.calculate_next_version(args.current, args.type)
+        if next_version:
+            print(next_version)
+            sys.exit(0)
+        else:
+            sys.exit(1)
+
+    elif args.command == "update-changelog":
+        success = helper.update_changelog(args.version, args.date)
+        sys.exit(0 if success else 1)
+
+    elif args.command == "validate":
+        valid, errors = helper.validate_prerequisites(args.type)
+        if valid:
+            print("✓ All prerequisites validated")
+            sys.exit(0)
+        else:
+            print("✗ Validation failed:", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == "detect":
+        print("Re-running auto-detection...")
+        detected = helper._auto_detect_version_files()
+        if detected:
+            config = {
+                "version_files": detected,
+                "changelog": "CHANGELOG.md",
+                "_comment": "Auto-generated by release helper. Edit as needed."
+            }
+            helper._save_config(config)
+            print(f"✓ Detected {len(detected)} version files")
+        else:
+            print("⚠️  No version files detected", file=sys.stderr)
+            sys.exit(1)
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ htmlcov/
 # Temporary
 *.tmp
 *.log
+
+# Release
+.release-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ htmlcov/
 
 # Release
 .release-config.json
+
+# Claude Code - only track release skill
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/release/

--- a/tests/test_release_helper.py
+++ b/tests/test_release_helper.py
@@ -19,9 +19,13 @@ from datetime import datetime
 
 import pytest
 
-# Try to import release_helper from skills directory
+# Try to import release_helper from project skills directory
 try:
-    sys.path.insert(0, str(Path.home() / ".claude" / "skills" / "release"))
+    # Get project root (parent of tests directory)
+    project_root = Path(__file__).parent.parent
+    skills_path = project_root / ".claude" / "skills" / "release"
+
+    sys.path.insert(0, str(skills_path))
     from release_helper import ReleaseHelper
     RELEASE_HELPER_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
@@ -31,7 +35,7 @@ except (ImportError, ModuleNotFoundError):
 # Skip all tests if release_helper is not available
 pytestmark = pytest.mark.skipif(
     not RELEASE_HELPER_AVAILABLE,
-    reason="release_helper module not available (skill not installed)"
+    reason="release_helper module not available (.claude/skills/release/ not found)"
 )
 
 
@@ -94,11 +98,10 @@ def test_get_current_version():
         create_test_repo(tmp_path)
 
         helper = ReleaseHelper(tmp_path)
-        pyproject_ver, init_ver, match = helper.get_current_version()
+        version, all_match = helper.get_current_version()
 
-        assert pyproject_ver == "1.1.0-dev"
-        assert init_ver == "1.1.0-dev"
-        assert match is True
+        assert version == "1.1.0-dev"
+        assert all_match is True
 
 
 def test_version_mismatch_detection():
@@ -114,11 +117,10 @@ def test_version_mismatch_detection():
         init_path.write_text(content)
 
         helper = ReleaseHelper(tmp_path)
-        pyproject_ver, init_ver, match = helper.get_current_version()
+        version, all_match = helper.get_current_version()
 
-        assert pyproject_ver == "1.1.0-dev"
-        assert init_ver == "1.2.0-dev"
-        assert match is False
+        assert version is None  # No single version when mismatch
+        assert all_match is False
 
 
 def test_update_version():
@@ -133,10 +135,9 @@ def test_update_version():
         assert success is True
 
         # Verify both files updated
-        pyproject_ver, init_ver, match = helper.get_current_version()
-        assert pyproject_ver == "1.2.0"
-        assert init_ver == "1.2.0"
-        assert match is True
+        version, all_match = helper.get_current_version()
+        assert version == "1.2.0"
+        assert all_match is True
 
 
 def test_calculate_next_version_minor():


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

## Description
This PR introduces a new release skill to automate the DevAIFlow release workflow. The skill has been designed to be project-agnostic with automatic detection capabilities, allowing it to work across different project structures without manual configuration.

Key changes:
- Created comprehensive release skill with documentation (README, EXAMPLE_USAGE, SKILL.md)
- Implemented `release_helper.py` with project auto-detection logic
- Added test coverage in `tests/test_release_helper.py`
- Configured `.gitignore` to properly track only the release skill files

The skill automates version management, CHANGELOG updates, and git operations for releases, reducing manual effort and potential errors in the release process.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Navigate to the project root
3. Review the release skill documentation in `.claude/skills/release/README.md` and `EXAMPLE_USAGE.md`
4. Run the test suite: `pytest tests/test_release_helper.py -v`
5. Optionally, test the skill invocation with `/release` (in a safe branch/environment)
6. Verify auto-detection works for different project structures (pyproject.toml, setup.py, etc.)

### Scenarios tested
- Unit tests for release_helper.py functions covering auto-detection logic
- Documentation reviewed for clarity and completeness
- .gitignore configuration verified to track release skill files correctly

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: