### PR TITLE
itdove/ai-guardian#25: Add disclaimers for self-blocking documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Documentation disclaimers for self-blocking behavior
+  - Prominent warning banner in README.md explaining why AI Guardian blocks its own documentation
+  - FAQ section addressing "is this a bug?" question about blocked README
+  - Developer warning in CONTRIBUTING.md with solutions for contributors
+  - Warning comments in ai-guardian-example.json about prompt injection examples
+  - Clear explanation that blocking documentation files is correct and expected behavior
 - GitHub Copilot support: Full integration with GitHub Copilot hooks
   - userPromptSubmitted hook for prompt scanning
   - preToolUse hook for tool permission checking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,52 @@ git push origin feature-name
 gh pr create --web
 ```
 
+## Working with AI Guardian Source Code
+
+**IMPORTANT for Contributors:** If you have AI Guardian installed and active, you may experience blocked file reads when working on this repository.
+
+**Why?** This project's documentation contains examples of prompt injection patterns that AI Guardian is designed to detect. When AI Guardian blocks these files, **it's working correctly!**
+
+**Files that may be blocked:**
+- `README.md` - Contains prompt injection pattern examples
+- `ai-guardian-example.json` - Contains pattern examples in comments
+- Test files with injection test cases
+
+**Solutions:**
+
+1. **View documentation on GitHub web** (recommended for reading docs):
+   - https://github.com/itdove/ai-guardian
+
+2. **Temporarily disable prompt injection detection** (for local development):
+   ```bash
+   # Edit ~/.config/ai-guardian/ai-guardian.json
+   # Set: "prompt_injection": {"enabled": false}
+   ```
+
+3. **Add personal allowlist pattern** (use with caution):
+   ```json
+   {
+     "prompt_injection": {
+       "enabled": true,
+       "allowlist_patterns": [
+         ".*/ai-guardian/.*"
+       ]
+     }
+   }
+   ```
+   ⚠️ **Warning**: This allows ALL files in ai-guardian repos to bypass detection. Only use if you understand the security implications.
+
+4. **Lower sensitivity** (alternative):
+   ```json
+   {
+     "prompt_injection": {
+       "sensitivity": "low"
+     }
+   }
+   ```
+
+See [Handling False Positives](README.md#handling-false-positives) in the README for more configuration options.
+
 ## Detailed Setup
 
 ### 1. Fork the Repository

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@
 
 AI Guardian provides comprehensive protection for AI IDE interactions through multiple security layers.
 
+> ⚠️ **IMPORTANT: Reading This Documentation with AI Guardian Active**
+> 
+> This README contains **examples of prompt injection patterns** that AI Guardian is designed to detect.
+> If you have AI Guardian installed and active, it may block you from reading this file in Claude Code or Cursor.
+> 
+> **This is AI Guardian working correctly!** 
+> 
+> To view this documentation:
+> - **Option 1**: View on GitHub web: https://github.com/itdove/ai-guardian
+> - **Option 2**: Temporarily disable: Edit `~/.config/ai-guardian/ai-guardian.json` and set `"enabled": false` under `prompt_injection`
+> - **Option 3**: Add allowlist pattern: `"allowlist_patterns": [".*ai-guardian.*"]`
+> - **Option 4**: Lower sensitivity: Set `"sensitivity": "low"` in config
+> 
+> See the [Handling False Positives](#handling-false-positives) section below for details.
+
 ## Quick Start
 
 ```bash
@@ -965,6 +980,19 @@ Apache 2.0 - see [LICENSE](LICENSE) file for details.
 - [Gitleaks](https://github.com/gitleaks/gitleaks) - Secret detection engine
 - [Claude Code](https://claude.ai/code) - AI-powered IDE
 - [Cursor](https://cursor.sh) - AI code editor
+
+## FAQ
+
+### Q: AI Guardian is blocking its own README.md file. Is this a bug?
+
+**A:** No, this is AI Guardian working correctly! The README contains examples of prompt injection patterns (like "ignore previous instructions") that demonstrate what the tool detects. 
+
+This is actually great validation that the tool works. To view the documentation:
+1. View on GitHub web: https://github.com/itdove/ai-guardian
+2. Add allowlist: `"allowlist_patterns": [".*ai-guardian.*"]`
+3. Temporarily disable: `"prompt_injection": {"enabled": false}`
+
+See [Handling False Positives](#handling-false-positives) for configuration details.
 
 ## Contributing
 

--- a/ai-guardian-example.json
+++ b/ai-guardian-example.json
@@ -1,4 +1,9 @@
 {
+  "_IMPORTANT_WARNING": "====================================================================",
+  "_WARNING1": "This file contains examples of prompt injection patterns in comments.",
+  "_WARNING2": "AI Guardian may block reading this file if active. This is EXPECTED!",
+  "_WARNING3": "To view this file: see README.md disclaimer for viewing options.",
+  "_WARNING4": "====================================================================",
   "_comment": "====================================================================",
   "_comment1": "AI Guardian Configuration - MCP Server and Skill Permissions",
   "_comment2": "====================================================================",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

## Description
This PR adds disclaimers and warnings to the documentation regarding self-blocking behavior in AI Guardian. The changes ensure users are properly informed about how the self-blocking feature works and its implications.

**Changes made:**
- Updated README.md with self-blocking behavior warnings
- Enhanced CONTRIBUTING.md with guidance on documenting self-blocking features
- Added CHANGELOG.md entry for documentation improvements
- Updated ai-guardian-example.json with relevant configuration examples

These documentation improvements help prevent misunderstandings about AI Guardian's self-blocking capabilities and provide clearer guidance for both users and contributors.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Review the updated documentation files (README.md, CONTRIBUTING.md)
3. Verify that the self-blocking warnings are clearly visible and understandable
4. Check that the markdown formatting renders correctly in GitHub
5. Ensure the CHANGELOG entry accurately reflects the documentation changes
6. Validate that the ai-guardian-example.json configuration examples are syntactically correct

### Scenarios tested
- Documentation review for clarity and accuracy
- Markdown rendering verification in local preview
- JSON syntax validation for example configuration file

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: