### PR TITLE
itdove/ai-guardian#23: Add violation/audit logging for blocked operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Violation/audit logging for blocked operations
+  - Tracks all blocked operations to `~/.config/ai-guardian/violations.jsonl`
+  - Logs tool permission blocks, directory access denials, secret detections, and prompt injections
+  - JSONL format for easy parsing and analysis
+  - Includes violation type, severity, blocked details, context, and suggestions
+  - Configurable log rotation (max_entries, retention_days)
+  - CLI command `ai-guardian violations` to view recent violations
+  - Filter violations by type with `--type` flag
+  - Export violations with `--export` flag
+  - Clear violation log with `--clear` flag
+  - Privacy-safe: no full secrets or prompts logged
+  - Foundation for future TUI integration (issue #22)
 - Security disclaimer and expanded documentation
   - Prominent security disclaimer banner in README.md after badges section
   - Clear statement that "AI Guardian is not a silver bullet"

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 from enum import Enum
 from pathlib import Path
+from typing import Dict, Optional
 
 from ai_guardian.config_utils import get_config_dir
 
@@ -47,6 +48,14 @@ try:
 except ImportError:
     HAS_PROMPT_INJECTION = False
     logging.debug("prompt_injection module not available")
+
+# Import violation logger
+try:
+    from ai_guardian.violation_logger import ViolationLogger
+    HAS_VIOLATION_LOGGER = True
+except ImportError:
+    HAS_VIOLATION_LOGGER = False
+    logging.debug("violation_logger module not available")
 
 # Configure logging - will be disabled for Cursor hooks
 logging.basicConfig(
@@ -290,6 +299,10 @@ def check_directory_denied(file_path):
 
             if os.path.exists(deny_marker):
                 logging.info(f"Found .ai-read-deny marker in {current_dir}")
+
+                # Log directory blocking violation
+                _log_directory_blocking_violation(file_path, current_dir)
+
                 return True, current_dir
 
             # Move to parent directory
@@ -574,6 +587,227 @@ def _is_ai_guardian_test_file(file_path):
     return has_ai_guardian and has_tests
 
 
+def _log_directory_blocking_violation(file_path: str, denied_directory: str):
+    """
+    Log a directory blocking violation.
+
+    Args:
+        file_path: Path to the file that was blocked
+        denied_directory: Directory containing .ai-read-deny marker
+    """
+    if not HAS_VIOLATION_LOGGER:
+        return
+
+    try:
+        violation_logger = ViolationLogger()
+        violation_logger.log_violation(
+            violation_type="directory_blocking",
+            blocked={
+                "file_path": file_path,
+                "denied_directory": denied_directory,
+                "reason": ".ai-read-deny marker found"
+            },
+            context={
+                "project_path": os.getcwd()
+            },
+            suggestion={
+                "action": "remove_deny_marker",
+                "file_path": os.path.join(denied_directory, ".ai-read-deny"),
+                "warning": "This directory contains sensitive files"
+            },
+            severity="warning"
+        )
+    except Exception as e:
+        logger.debug(f"Failed to log directory blocking violation: {e}")
+
+
+def _log_secret_detection_violation(filename: str, context: Optional[Dict] = None):
+    """
+    Log a secret detection violation.
+
+    Args:
+        filename: Name of the file/prompt where secret was detected
+        context: Optional context dict with ide_type, hook_event, etc.
+    """
+    if not HAS_VIOLATION_LOGGER:
+        return
+
+    try:
+        ctx = context or {}
+        violation_logger = ViolationLogger()
+        violation_logger.log_violation(
+            violation_type="secret_detected",
+            blocked={
+                "file_path": filename if filename != "user_prompt" else None,
+                "source": "prompt" if filename == "user_prompt" else "file",
+                "secret_type": "Unknown",  # Gitleaks doesn't expose this easily
+                "reason": "Gitleaks detected sensitive information"
+            },
+            context={
+                "ide_type": ctx.get("ide_type", "unknown"),
+                "hook_event": ctx.get("hook_event", "unknown"),
+                "project_path": os.getcwd()
+            },
+            suggestion={
+                "action": "review_and_remove_secret",
+                "warning": "Secrets should never be committed to code or shared with AI"
+            },
+            severity="critical"
+        )
+    except Exception as e:
+        logger.debug(f"Failed to log secret detection violation: {e}")
+
+
+def _log_prompt_injection_violation(filename: str, context: Optional[Dict] = None):
+    """
+    Log a prompt injection violation.
+
+    Args:
+        filename: Name of the file/prompt where injection was detected
+        context: Optional context dict with ide_type, hook_event, etc.
+    """
+    if not HAS_VIOLATION_LOGGER:
+        return
+
+    try:
+        ctx = context or {}
+        violation_logger = ViolationLogger()
+        violation_logger.log_violation(
+            violation_type="prompt_injection",
+            blocked={
+                "file_path": filename if filename != "user_prompt" else None,
+                "source": "prompt" if filename == "user_prompt" else "file",
+                "pattern": "Heuristic pattern detected",
+                "confidence": 0.95,
+                "method": "heuristic",
+                "reason": "Prompt injection pattern detected"
+            },
+            context={
+                "ide_type": ctx.get("ide_type", "unknown"),
+                "hook_event": ctx.get("hook_event", "unknown"),
+                "project_path": os.getcwd()
+            },
+            suggestion={
+                "action": "add_allowlist_pattern",
+                "note": "If this is legitimate (e.g., documentation), add to allowlist in ai-guardian.json"
+            },
+            severity="high"
+        )
+    except Exception as e:
+        logger.debug(f"Failed to log prompt injection violation: {e}")
+
+
+def _handle_violations_command(args):
+    """
+    Handle the violations subcommand.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        int: Exit code (0 for success, 1 for error)
+    """
+    from ai_guardian.violation_logger import ViolationLogger
+
+    violation_logger = ViolationLogger()
+
+    # Handle --clear
+    if args.clear:
+        confirm = input("Are you sure you want to clear all violations? [y/N] ")
+        if confirm.lower() == 'y':
+            if violation_logger.clear_log():
+                print("Violations log cleared successfully")
+                return 0
+            else:
+                print("Error: Failed to clear violations log", file=sys.stderr)
+                return 1
+        else:
+            print("Cancelled")
+            return 0
+
+    # Handle --export
+    if args.export:
+        export_path = Path(args.export)
+        if violation_logger.export_violations(export_path, violation_type=args.type):
+            print(f"Violations exported to {export_path}")
+            return 0
+        else:
+            print(f"Error: Failed to export violations to {export_path}", file=sys.stderr)
+            return 1
+
+    # Display violations
+    violations = violation_logger.get_recent_violations(
+        limit=args.limit,
+        violation_type=args.type,
+        resolved=False  # Only show unresolved violations by default
+    )
+
+    if not violations:
+        print("No recent violations found")
+        return 0
+
+    # Format and display violations
+    print(f"\nRecent Violations (last {len(violations)}):\n")
+
+    for v in violations:
+        timestamp = v.get("timestamp", "Unknown")
+        vtype = v.get("violation_type", "unknown").upper().replace("_", " ")
+        severity = v.get("severity", "warning").upper()
+        blocked = v.get("blocked", {})
+        suggestion = v.get("suggestion", {})
+
+        # Format severity with color indicators
+        severity_indicator = {
+            "WARNING": "⚠",
+            "HIGH": "🔴",
+            "CRITICAL": "🔒"
+        }.get(severity, "•")
+
+        print(f"[{timestamp}] {severity_indicator} {vtype} ({severity.lower()})")
+
+        # Display blocked details based on violation type
+        if v.get("violation_type") == "tool_permission":
+            tool_name = blocked.get("tool_name", "Unknown")
+            tool_value = blocked.get("tool_value", "")
+            reason = blocked.get("reason", "")
+            print(f"  Tool: {tool_name}/{tool_value}")
+            print(f"  Reason: {reason}")
+
+        elif v.get("violation_type") == "directory_blocking":
+            file_path = blocked.get("file_path", "Unknown")
+            denied_dir = blocked.get("denied_directory", "")
+            print(f"  File: {file_path}")
+            print(f"  Denied by: {denied_dir}/.ai-read-deny")
+
+        elif v.get("violation_type") == "secret_detected":
+            source = blocked.get("source", "unknown")
+            file_path = blocked.get("file_path")
+            if file_path:
+                print(f"  File: {file_path}")
+            else:
+                print(f"  Source: {source}")
+            secret_type = blocked.get("secret_type", "Unknown")
+            print(f"  Secret type: {secret_type}")
+
+        elif v.get("violation_type") == "prompt_injection":
+            source = blocked.get("source", "unknown")
+            pattern = blocked.get("pattern", "Unknown")
+            print(f"  Source: {source}")
+            print(f"  Pattern: {pattern}")
+
+        # Display suggestion
+        action = suggestion.get("action", "")
+        if action:
+            print(f"  → Suggestion: {action}")
+
+        print()
+
+    print(f"To allow blocked operations, run: ai-guardian tui (when available)")
+    print(f"Or manually edit: ~/.config/ai-guardian/ai-guardian.json\n")
+
+    return 0
+
+
 def _is_gitleaks_config_content(content):
     """
     Detect if content looks like a gitleaks configuration file.
@@ -599,7 +833,7 @@ def _is_gitleaks_config_content(content):
     return matches >= 3
 
 
-def check_secrets_with_gitleaks(content, filename="temp_file"):
+def check_secrets_with_gitleaks(content, filename="temp_file", context: Optional[Dict] = None):
     """
     Check content for secrets using Gitleaks binary.
 
@@ -611,6 +845,7 @@ def check_secrets_with_gitleaks(content, filename="temp_file"):
     Args:
         content: The text content to scan for secrets
         filename: Optional filename for context in error messages
+        context: Optional context dict for violation logging (ide_type, hook_event, etc.)
 
     Returns:
         tuple: (has_secrets: bool, error_message: str or None)
@@ -698,6 +933,10 @@ def check_secrets_with_gitleaks(content, filename="temp_file"):
                     "https://github.com/gitleaks/gitleaks#configuration\n"
                     f"\n{'='*70}\n"
                 )
+
+                # Log secret detection violation
+                _log_secret_detection_violation(filename, context)
+
                 return True, error_msg
 
             elif result.returncode in [0, 1]:
@@ -801,7 +1040,8 @@ def process_hook_input():
 
             # Check for secrets in the output
             has_secrets, error_message = check_secrets_with_gitleaks(
-                tool_output, f"{tool_name}_output"
+                tool_output, f"{tool_name}_output",
+                context={"ide_type": ide_type.value, "hook_event": "posttooluse"}
             )
 
             if has_secrets:
@@ -880,6 +1120,13 @@ def process_hook_input():
                     # Prompt injection detected - block operation
                     if ide_type != IDEType.CURSOR:
                         logging.warning("Prompt injection detected, blocking operation")
+
+                    # Log prompt injection violation
+                    _log_prompt_injection_violation(
+                        filename,
+                        context={"ide_type": ide_type.value, "hook_event": hook_event}
+                    )
+
                     return format_response(ide_type, has_secrets=True, error_message=injection_error, hook_event=hook_event)
 
                 if ide_type != IDEType.CURSOR:
@@ -890,7 +1137,8 @@ def process_hook_input():
 
         # Check for secrets in the content
         has_secrets, error_message = check_secrets_with_gitleaks(
-            content_to_scan, filename
+            content_to_scan, filename,
+            context={"ide_type": ide_type.value, "hook_event": hook_event}
         )
 
         if has_secrets:
@@ -967,6 +1215,33 @@ def main():
             help="Skip confirmation prompts"
         )
 
+        # Violations subcommand
+        violations_parser = subparsers.add_parser(
+            "violations",
+            help="View and manage violation log"
+        )
+        violations_parser.add_argument(
+            "--type",
+            choices=["tool_permission", "directory_blocking", "secret_detected", "prompt_injection"],
+            help="Filter by violation type"
+        )
+        violations_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of violations to show (default: 10)"
+        )
+        violations_parser.add_argument(
+            "--clear",
+            action="store_true",
+            help="Clear all violations from log"
+        )
+        violations_parser.add_argument(
+            "--export",
+            metavar="FILE",
+            help="Export violations to JSON file"
+        )
+
         args = parser.parse_args()
 
         # Handle setup command
@@ -980,6 +1255,14 @@ def main():
                 interactive=not args.yes
             )
             return 0 if success else 1
+
+        # Handle violations command
+        if args.command == "violations":
+            if HAS_VIOLATION_LOGGER:
+                return _handle_violations_command(args)
+            else:
+                print("Error: violation_logger module not available", file=sys.stderr)
+                return 1
 
         # If no subcommand, just return (version was handled)
         return 0

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -20,6 +20,14 @@ from typing import Dict, List, Optional, Tuple, Set
 
 from ai_guardian.config_utils import get_config_dir
 
+# Import violation logger
+try:
+    from ai_guardian.violation_logger import ViolationLogger
+    HAS_VIOLATION_LOGGER = True
+except ImportError:
+    HAS_VIOLATION_LOGGER = False
+    logging.debug("violation_logger module not available")
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,6 +84,16 @@ class ToolPolicyChecker:
                 if self._requires_explicit_allow(tool_name):
                     logger.warning(f"Tool '{tool_name}' requires explicit permission but no rule found")
                     error_msg = self._format_deny_message(tool_name, "no permission rule", None)
+
+                    # Log violation
+                    self._log_violation(
+                        tool_name=tool_name,
+                        check_value=check_value if check_value else tool_name,
+                        reason="no permission rule",
+                        matcher=tool_name,
+                        hook_data=hook_data
+                    )
+
                     return False, error_msg, tool_name
 
                 # No rule and doesn't require explicit allow - allow by default
@@ -105,6 +123,16 @@ class ToolPolicyChecker:
                         if fnmatch.fnmatch(check_value, pattern):
                             logger.warning(f"Tool '{tool_name}' matched deny pattern: {pattern}")
                             error_msg = self._format_deny_message(tool_name, pattern, rule["matcher"])
+
+                            # Log violation
+                            self._log_violation(
+                                tool_name=tool_name,
+                                check_value=check_value,
+                                reason=f"matched deny pattern: {pattern}",
+                                matcher=rule["matcher"],
+                                hook_data=hook_data
+                            )
+
                             return False, error_msg, tool_name
 
             # Second pass: check allow rules
@@ -129,6 +157,16 @@ class ToolPolicyChecker:
             if has_allow_rules:
                 logger.warning(f"Tool '{tool_name}' not in allow list")
                 error_msg = self._format_deny_message(tool_name, "not in allow list", permission_rules[0]["matcher"])
+
+                # Log violation
+                self._log_violation(
+                    tool_name=tool_name,
+                    check_value=check_value,
+                    reason="not in allow list",
+                    matcher=permission_rules[0]["matcher"],
+                    hook_data=hook_data
+                )
+
                 return False, error_msg, tool_name
 
             # No allow rules - allow by default (already passed deny check)
@@ -357,6 +395,95 @@ class ToolPolicyChecker:
         return tool_name, [
             {"pattern": "*", "comment": f"Allow all {tool_name} operations"}
         ]
+
+    def _log_violation(
+        self,
+        tool_name: str,
+        check_value: str,
+        reason: str,
+        matcher: str,
+        hook_data: Dict
+    ):
+        """
+        Log a tool permission violation.
+
+        Args:
+            tool_name: Name of the blocked tool
+            check_value: Value that was checked against patterns
+            reason: Reason for blocking
+            matcher: Matcher pattern from the permission rule
+            hook_data: Original hook data for context
+        """
+        if not HAS_VIOLATION_LOGGER:
+            return
+
+        try:
+            # Detect IDE type from hook data
+            ide_type = self._detect_ide_type(hook_data)
+
+            # Generate suggested rule
+            suggested_matcher, suggested_patterns = self._suggest_permission_rule(tool_name)
+
+            # Create violation logger
+            violation_logger = ViolationLogger()
+
+            # Log the violation
+            violation_logger.log_violation(
+                violation_type="tool_permission",
+                blocked={
+                    "tool_name": tool_name,
+                    "tool_value": check_value,
+                    "matcher": matcher,
+                    "reason": reason
+                },
+                context={
+                    "ide_type": ide_type,
+                    "hook_event": hook_data.get("hook_event_name"),
+                    "project_path": os.getcwd()
+                },
+                suggestion={
+                    "action": "add_allow_pattern",
+                    "config_path": str(get_config_dir() / "ai-guardian.json"),
+                    "rule": {
+                        "matcher": suggested_matcher,
+                        "mode": "allow",
+                        "patterns": [p["pattern"] for p in suggested_patterns]
+                    }
+                },
+                severity="warning"
+            )
+
+        except Exception as e:
+            logger.debug(f"Failed to log violation: {e}")
+
+    def _detect_ide_type(self, hook_data: Dict) -> str:
+        """
+        Detect IDE type from hook data.
+
+        Args:
+            hook_data: Hook data from PreToolUse event
+
+        Returns:
+            str: IDE type (claude_code, cursor, github_copilot, unknown)
+        """
+        # Check for environment variable override
+        ide_override = os.environ.get("AI_GUARDIAN_IDE_TYPE", "").lower()
+        if ide_override:
+            return ide_override
+
+        # GitHub Copilot detection
+        if "toolName" in hook_data or ("timestamp" in hook_data and "cwd" in hook_data):
+            return "github_copilot"
+
+        # Cursor detection
+        if "cursor_version" in hook_data or "hook_name" in hook_data:
+            return "cursor"
+
+        # Claude Code detection
+        if "hook_event_name" in hook_data and hook_data.get("hook_event_name") in ["UserPromptSubmit", "PreToolUse"]:
+            return "claude_code"
+
+        return "unknown"
 
     def _load_config(self) -> Dict:
         """

--- a/src/ai_guardian/violation_logger.py
+++ b/src/ai_guardian/violation_logger.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Violation Logger Module
+
+Logs blocked operations to a JSONL file for audit and review.
+Supports violation types:
+- tool_permission: Tool/skill blocked by policy
+- directory_blocking: File in denied directory
+- secret_detected: Gitleaks found secrets
+- prompt_injection: Malicious prompt detected
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ai_guardian.config_utils import get_config_dir
+
+logger = logging.getLogger(__name__)
+
+
+class ViolationLogger:
+    """Log blocked operations for audit and TUI review."""
+
+    def __init__(self, log_path: Optional[Path] = None, config: Optional[Dict] = None):
+        """
+        Initialize violation logger.
+
+        Args:
+            log_path: Optional custom log file path
+            config: Optional configuration dict
+        """
+        self.config = config or self._load_config()
+
+        # Determine log path
+        if log_path is None:
+            config_dir = get_config_dir()
+            log_path = config_dir / "violations.jsonl"
+
+        self.log_path = log_path
+
+        # Only create log directory if logging is enabled
+        if self._is_logging_enabled():
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log_violation(
+        self,
+        violation_type: str,
+        blocked: Dict,
+        context: Dict,
+        suggestion: Optional[Dict] = None,
+        severity: str = "warning"
+    ):
+        """
+        Log a violation to JSONL file.
+
+        Args:
+            violation_type: Type of violation (tool_permission, directory_blocking, etc.)
+            blocked: Details about what was blocked
+            context: Context information (IDE type, project path, etc.)
+            suggestion: Optional suggestion for resolving the violation
+            severity: Severity level (warning, high, critical)
+        """
+        # Check if logging is enabled
+        if not self._is_logging_enabled():
+            logger.debug("Violation logging is disabled")
+            return
+
+        # Check if this violation type should be logged
+        if not self._should_log_type(violation_type):
+            logger.debug(f"Violation type {violation_type} is not configured to be logged")
+            return
+
+        try:
+            entry = {
+                "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
+                "violation_type": violation_type,
+                "severity": severity,
+                "blocked": blocked,
+                "context": context,
+                "suggestion": suggestion or {},
+                "resolved": False,
+                "resolved_at": None,
+                "resolved_action": None
+            }
+
+            # Append to JSONL file
+            with open(self.log_path, 'a', encoding='utf-8') as f:
+                f.write(json.dumps(entry) + '\n')
+
+            logger.debug(f"Logged {violation_type} violation to {self.log_path}")
+
+            # Rotate log if needed
+            self._rotate_log_if_needed()
+
+        except Exception as e:
+            # Fail-open: don't block operations if logging fails
+            logger.warning(f"Failed to log violation: {e}")
+
+    def get_recent_violations(
+        self,
+        limit: int = 50,
+        violation_type: Optional[str] = None,
+        resolved: Optional[bool] = None
+    ) -> List[Dict]:
+        """
+        Get recent violations from log.
+
+        Args:
+            limit: Maximum number of violations to return
+            violation_type: Optional filter by violation type
+            resolved: Optional filter by resolved status (True/False/None for all)
+
+        Returns:
+            list: List of violation entries (most recent first)
+        """
+        if not self.log_path.exists():
+            return []
+
+        violations = []
+        try:
+            with open(self.log_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+
+                        # Apply filters
+                        if violation_type is not None and entry.get("violation_type") != violation_type:
+                            continue
+
+                        if resolved is not None and entry.get("resolved", False) != resolved:
+                            continue
+
+                        violations.append(entry)
+
+                    except json.JSONDecodeError as e:
+                        logger.warning(f"Skipping invalid JSON line: {e}")
+                        continue
+
+            # Return most recent first
+            violations = violations[-limit:][::-1]
+            return violations
+
+        except Exception as e:
+            logger.error(f"Error reading violations log: {e}")
+            return []
+
+    def mark_resolved(
+        self,
+        timestamp: str,
+        action: str = "approved",
+        note: Optional[str] = None
+    ) -> bool:
+        """
+        Mark a violation as resolved.
+
+        Args:
+            timestamp: Timestamp of the violation to resolve
+            action: Resolution action (approved, denied, etc.)
+            note: Optional note about resolution
+
+        Returns:
+            bool: True if violation was found and marked resolved
+        """
+        if not self.log_path.exists():
+            return False
+
+        try:
+            # Read all violations
+            violations = []
+            with open(self.log_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                        violations.append(entry)
+                    except json.JSONDecodeError:
+                        continue
+
+            # Find and update the violation
+            found = False
+            for entry in violations:
+                if entry.get("timestamp") == timestamp:
+                    entry["resolved"] = True
+                    entry["resolved_at"] = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+                    entry["resolved_action"] = action
+                    if note:
+                        entry["resolved_note"] = note
+                    found = True
+                    break
+
+            if not found:
+                return False
+
+            # Write back all violations
+            with open(self.log_path, 'w', encoding='utf-8') as f:
+                for entry in violations:
+                    f.write(json.dumps(entry) + '\n')
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Error marking violation as resolved: {e}")
+            return False
+
+    def clear_log(self) -> bool:
+        """
+        Clear the violations log.
+
+        Returns:
+            bool: True if log was cleared successfully
+        """
+        try:
+            if self.log_path.exists():
+                self.log_path.unlink()
+                logger.info(f"Cleared violations log at {self.log_path}")
+            return True
+        except Exception as e:
+            logger.error(f"Error clearing violations log: {e}")
+            return False
+
+    def export_violations(self, export_path: Path, violation_type: Optional[str] = None) -> bool:
+        """
+        Export violations to a JSON file.
+
+        Args:
+            export_path: Path to export file
+            violation_type: Optional filter by violation type
+
+        Returns:
+            bool: True if export was successful
+        """
+        try:
+            violations = self.get_recent_violations(
+                limit=10000,  # Export all violations
+                violation_type=violation_type
+            )
+
+            with open(export_path, 'w', encoding='utf-8') as f:
+                json.dump(violations, f, indent=2)
+
+            logger.info(f"Exported {len(violations)} violations to {export_path}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error exporting violations: {e}")
+            return False
+
+    def _load_config(self) -> Dict:
+        """
+        Load violation logging configuration from ai-guardian.json.
+
+        Returns:
+            dict: Configuration or defaults
+        """
+        try:
+            config_dir = get_config_dir()
+            config_path = config_dir / "ai-guardian.json"
+
+            if not config_path.exists():
+                # Try project local config
+                config_path = Path.cwd() / ".ai-guardian.json"
+
+            if not config_path.exists():
+                return self._get_default_config()
+
+            with open(config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+
+            return config.get("violation_logging", self._get_default_config())
+
+        except Exception as e:
+            logger.debug(f"Error loading violation logging config: {e}")
+            return self._get_default_config()
+
+    def _get_default_config(self) -> Dict:
+        """Get default configuration."""
+        return {
+            "enabled": True,
+            "max_entries": 1000,
+            "retention_days": 30,
+            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "prompt_injection"]
+        }
+
+    def _is_logging_enabled(self) -> bool:
+        """Check if violation logging is enabled."""
+        return self.config.get("enabled", True)
+
+    def _should_log_type(self, violation_type: str) -> bool:
+        """Check if a violation type should be logged."""
+        log_types = self.config.get("log_types", [])
+        # If log_types is empty or not configured, log all types
+        if not log_types:
+            return True
+        return violation_type in log_types
+
+    def _rotate_log_if_needed(self):
+        """Rotate log file if it exceeds max_entries or retention_days."""
+        try:
+            if not self.log_path.exists():
+                return
+
+            max_entries = self.config.get("max_entries", 1000)
+            retention_days = self.config.get("retention_days", 30)
+
+            # Read all violations
+            violations = []
+            with open(self.log_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                        violations.append(entry)
+                    except json.JSONDecodeError:
+                        continue
+
+            # Filter by retention days
+            cutoff_date = datetime.now(timezone.utc) - timedelta(days=retention_days)
+            violations = [
+                v for v in violations
+                if self._parse_timestamp(v.get("timestamp")) > cutoff_date
+            ]
+
+            # Limit by max_entries (keep most recent)
+            if len(violations) > max_entries:
+                violations = violations[-max_entries:]
+
+            # Write back filtered violations
+            with open(self.log_path, 'w', encoding='utf-8') as f:
+                for entry in violations:
+                    f.write(json.dumps(entry) + '\n')
+
+            logger.debug(f"Log rotation: kept {len(violations)} violations")
+
+        except Exception as e:
+            logger.warning(f"Error rotating log: {e}")
+
+    def _parse_timestamp(self, timestamp_str: Optional[str]) -> datetime:
+        """
+        Parse ISO timestamp string to datetime.
+
+        Args:
+            timestamp_str: ISO format timestamp string
+
+        Returns:
+            datetime: Parsed datetime (timezone-aware) or epoch if parsing fails
+        """
+        if not timestamp_str:
+            return datetime.fromtimestamp(0, tz=timezone.utc)
+
+        try:
+            # Remove 'Z' suffix and parse as UTC
+            if timestamp_str.endswith('Z'):
+                timestamp_str = timestamp_str[:-1] + '+00:00'
+            dt = datetime.fromisoformat(timestamp_str)
+            # Ensure timezone-aware
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except (ValueError, AttributeError):
+            return datetime.fromtimestamp(0, tz=timezone.utc)

--- a/tests/test_violation_logger.py
+++ b/tests/test_violation_logger.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""
+Tests for ViolationLogger module
+"""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ai_guardian.violation_logger import ViolationLogger
+
+
+@pytest.fixture
+def temp_log_file():
+    """Create a temporary log file for testing."""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+        log_path = Path(f.name)
+
+    yield log_path
+
+    # Cleanup
+    if log_path.exists():
+        log_path.unlink()
+
+
+@pytest.fixture
+def violation_logger(temp_log_file):
+    """Create a ViolationLogger instance with temp log file."""
+    return ViolationLogger(log_path=temp_log_file)
+
+
+def test_log_violation_creates_file(violation_logger, temp_log_file):
+    """Test that logging a violation creates the log file."""
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Skill", "reason": "not in allow list"},
+        context={"ide_type": "claude_code"},
+        severity="warning"
+    )
+
+    assert temp_log_file.exists()
+
+
+def test_log_violation_jsonl_format(violation_logger, temp_log_file):
+    """Test that violations are logged in JSONL format."""
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Skill", "tool_value": "test-skill", "reason": "not in allow list"},
+        context={"ide_type": "claude_code"},
+        suggestion={"action": "add_allow_pattern"},
+        severity="warning"
+    )
+
+    # Read and parse the log file
+    with open(temp_log_file, 'r') as f:
+        lines = f.readlines()
+
+    assert len(lines) == 1
+
+    entry = json.loads(lines[0])
+    assert entry["violation_type"] == "tool_permission"
+    assert entry["severity"] == "warning"
+    assert entry["blocked"]["tool_name"] == "Skill"
+    assert entry["blocked"]["tool_value"] == "test-skill"
+    assert entry["context"]["ide_type"] == "claude_code"
+    assert entry["suggestion"]["action"] == "add_allow_pattern"
+    assert "timestamp" in entry
+    assert entry["resolved"] is False
+
+
+def test_log_multiple_violations(violation_logger, temp_log_file):
+    """Test logging multiple violations."""
+    for i in range(5):
+        violation_logger.log_violation(
+            violation_type="tool_permission",
+            blocked={"tool_name": f"Tool{i}"},
+            context={"project_path": "/test"},
+            severity="warning"
+        )
+
+    with open(temp_log_file, 'r') as f:
+        lines = f.readlines()
+
+    assert len(lines) == 5
+
+
+def test_get_recent_violations(violation_logger):
+    """Test getting recent violations."""
+    # Log some violations
+    for i in range(5):
+        violation_logger.log_violation(
+            violation_type="tool_permission",
+            blocked={"tool_name": f"Tool{i}"},
+            context={},
+            severity="warning"
+        )
+
+    violations = violation_logger.get_recent_violations(limit=10)
+    assert len(violations) == 5
+
+    # Should be in reverse order (most recent first)
+    assert violations[0]["blocked"]["tool_name"] == "Tool4"
+    assert violations[-1]["blocked"]["tool_name"] == "Tool0"
+
+
+def test_get_recent_violations_with_limit(violation_logger):
+    """Test getting violations with limit."""
+    # Log 10 violations
+    for i in range(10):
+        violation_logger.log_violation(
+            violation_type="tool_permission",
+            blocked={"tool_name": f"Tool{i}"},
+            context={},
+            severity="warning"
+        )
+
+    violations = violation_logger.get_recent_violations(limit=3)
+    assert len(violations) == 3
+
+    # Should get the 3 most recent
+    assert violations[0]["blocked"]["tool_name"] == "Tool9"
+    assert violations[1]["blocked"]["tool_name"] == "Tool8"
+    assert violations[2]["blocked"]["tool_name"] == "Tool7"
+
+
+def test_get_recent_violations_filter_by_type(violation_logger):
+    """Test filtering violations by type."""
+    # Log different types
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Skill"},
+        context={},
+        severity="warning"
+    )
+    violation_logger.log_violation(
+        violation_type="secret_detected",
+        blocked={"file_path": "test.py"},
+        context={},
+        severity="critical"
+    )
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Bash"},
+        context={},
+        severity="warning"
+    )
+
+    # Filter by tool_permission
+    violations = violation_logger.get_recent_violations(
+        limit=10,
+        violation_type="tool_permission"
+    )
+    assert len(violations) == 2
+    assert all(v["violation_type"] == "tool_permission" for v in violations)
+
+    # Filter by secret_detected
+    violations = violation_logger.get_recent_violations(
+        limit=10,
+        violation_type="secret_detected"
+    )
+    assert len(violations) == 1
+    assert violations[0]["violation_type"] == "secret_detected"
+
+
+def test_get_recent_violations_filter_by_resolved(violation_logger, temp_log_file):
+    """Test filtering violations by resolved status."""
+    # Log some violations
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Tool1"},
+        context={},
+        severity="warning"
+    )
+
+    # Get the timestamp
+    violations = violation_logger.get_recent_violations(limit=10)
+    timestamp = violations[0]["timestamp"]
+
+    # Mark it as resolved
+    violation_logger.mark_resolved(timestamp, action="approved")
+
+    # Log another violation
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Tool2"},
+        context={},
+        severity="warning"
+    )
+
+    # Get only unresolved
+    unresolved = violation_logger.get_recent_violations(limit=10, resolved=False)
+    assert len(unresolved) == 1
+    assert unresolved[0]["blocked"]["tool_name"] == "Tool2"
+
+    # Get only resolved
+    resolved = violation_logger.get_recent_violations(limit=10, resolved=True)
+    assert len(resolved) == 1
+    assert resolved[0]["blocked"]["tool_name"] == "Tool1"
+
+
+def test_mark_resolved(violation_logger):
+    """Test marking a violation as resolved."""
+    # Log a violation
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "TestTool"},
+        context={},
+        severity="warning"
+    )
+
+    # Get the timestamp
+    violations = violation_logger.get_recent_violations(limit=10)
+    timestamp = violations[0]["timestamp"]
+
+    # Mark as resolved
+    result = violation_logger.mark_resolved(timestamp, action="approved", note="User approved")
+    assert result is True
+
+    # Verify it was marked resolved
+    violations = violation_logger.get_recent_violations(limit=10)
+    assert violations[0]["resolved"] is True
+    assert violations[0]["resolved_action"] == "approved"
+    assert violations[0]["resolved_note"] == "User approved"
+    assert "resolved_at" in violations[0]
+
+
+def test_mark_resolved_nonexistent(violation_logger):
+    """Test marking a nonexistent violation as resolved."""
+    result = violation_logger.mark_resolved("2026-04-11T00:00:00Z", action="approved")
+    assert result is False
+
+
+def test_clear_log(violation_logger, temp_log_file):
+    """Test clearing the violations log."""
+    # Log some violations
+    for i in range(5):
+        violation_logger.log_violation(
+            violation_type="tool_permission",
+            blocked={"tool_name": f"Tool{i}"},
+            context={},
+            severity="warning"
+        )
+
+    assert temp_log_file.exists()
+
+    # Clear the log
+    result = violation_logger.clear_log()
+    assert result is True
+    assert not temp_log_file.exists()
+
+    # Verify no violations
+    violations = violation_logger.get_recent_violations(limit=10)
+    assert len(violations) == 0
+
+
+def test_export_violations(violation_logger):
+    """Test exporting violations to JSON."""
+    # Log some violations
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Tool1"},
+        context={},
+        severity="warning"
+    )
+    violation_logger.log_violation(
+        violation_type="secret_detected",
+        blocked={"file_path": "test.py"},
+        context={},
+        severity="critical"
+    )
+
+    # Export to temp file
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+        export_path = Path(f.name)
+
+    try:
+        result = violation_logger.export_violations(export_path)
+        assert result is True
+        assert export_path.exists()
+
+        # Verify exported data
+        with open(export_path, 'r') as f:
+            exported = json.load(f)
+
+        assert len(exported) == 2
+        assert exported[0]["violation_type"] == "secret_detected"  # Most recent first
+        assert exported[1]["violation_type"] == "tool_permission"
+    finally:
+        if export_path.exists():
+            export_path.unlink()
+
+
+def test_export_violations_with_filter(violation_logger):
+    """Test exporting violations with type filter."""
+    # Log different types
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Tool1"},
+        context={},
+        severity="warning"
+    )
+    violation_logger.log_violation(
+        violation_type="secret_detected",
+        blocked={"file_path": "test.py"},
+        context={},
+        severity="critical"
+    )
+
+    # Export only tool_permission violations
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+        export_path = Path(f.name)
+
+    try:
+        result = violation_logger.export_violations(
+            export_path,
+            violation_type="tool_permission"
+        )
+        assert result is True
+
+        with open(export_path, 'r') as f:
+            exported = json.load(f)
+
+        assert len(exported) == 1
+        assert exported[0]["violation_type"] == "tool_permission"
+    finally:
+        if export_path.exists():
+            export_path.unlink()
+
+
+def test_log_rotation_max_entries(temp_log_file):
+    """Test log rotation based on max_entries."""
+    config = {
+        "enabled": True,
+        "max_entries": 5,
+        "retention_days": 30,
+        "log_types": ["tool_permission"]
+    }
+
+    violation_logger = ViolationLogger(log_path=temp_log_file, config=config)
+
+    # Log 10 violations
+    for i in range(10):
+        violation_logger.log_violation(
+            violation_type="tool_permission",
+            blocked={"tool_name": f"Tool{i}"},
+            context={},
+            severity="warning"
+        )
+
+    # Should only keep the last 5
+    violations = violation_logger.get_recent_violations(limit=100)
+    assert len(violations) <= 5
+
+    # Should keep the most recent ones
+    if len(violations) == 5:
+        assert violations[0]["blocked"]["tool_name"] == "Tool9"
+
+
+def test_logging_disabled(temp_log_file):
+    """Test that logging can be disabled."""
+    config = {
+        "enabled": False,
+        "max_entries": 1000,
+        "retention_days": 30,
+        "log_types": ["tool_permission"]
+    }
+
+    violation_logger = ViolationLogger(log_path=temp_log_file, config=config)
+
+    # Try to log a violation
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Tool1"},
+        context={},
+        severity="warning"
+    )
+
+    # Log file should either not exist or be empty
+    if temp_log_file.exists():
+        # If the fixture created the file, it should be empty
+        with open(temp_log_file, 'r') as f:
+            content = f.read()
+        assert content == "", "Log file should be empty when logging is disabled"
+    # Otherwise, it should not exist
+    # (This handles the case where the directory wasn't created)
+
+
+def test_log_type_filtering(temp_log_file):
+    """Test that only configured violation types are logged."""
+    config = {
+        "enabled": True,
+        "max_entries": 1000,
+        "retention_days": 30,
+        "log_types": ["tool_permission", "secret_detected"]  # Only these types
+    }
+
+    violation_logger = ViolationLogger(log_path=temp_log_file, config=config)
+
+    # Log allowed type
+    violation_logger.log_violation(
+        violation_type="tool_permission",
+        blocked={"tool_name": "Tool1"},
+        context={},
+        severity="warning"
+    )
+
+    # Log disallowed type
+    violation_logger.log_violation(
+        violation_type="prompt_injection",
+        blocked={"pattern": "test"},
+        context={},
+        severity="high"
+    )
+
+    # Only tool_permission should be logged
+    violations = violation_logger.get_recent_violations(limit=10)
+    assert len(violations) == 1
+    assert violations[0]["violation_type"] == "tool_permission"
+
+
+def test_violation_types():
+    """Test all violation types with expected schema."""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.jsonl') as f:
+        log_path = Path(f.name)
+
+    try:
+        violation_logger = ViolationLogger(log_path=log_path)
+
+        # Test tool_permission
+        violation_logger.log_violation(
+            violation_type="tool_permission",
+            blocked={
+                "tool_name": "Skill",
+                "tool_value": "daf-jira",
+                "matcher": "Skill",
+                "reason": "not in allow list"
+            },
+            context={"ide_type": "claude_code"},
+            suggestion={
+                "action": "add_allow_pattern",
+                "rule": {"matcher": "Skill", "mode": "allow", "patterns": ["daf-jira"]}
+            },
+            severity="warning"
+        )
+
+        # Test directory_blocking
+        violation_logger.log_violation(
+            violation_type="directory_blocking",
+            blocked={
+                "file_path": "/home/user/secrets/config.yaml",
+                "denied_directory": "/home/user/secrets",
+                "reason": ".ai-read-deny marker found"
+            },
+            context={"project_path": "/home/user/project"},
+            suggestion={
+                "action": "remove_deny_marker",
+                "file_path": "/home/user/secrets/.ai-read-deny"
+            },
+            severity="warning"
+        )
+
+        # Test secret_detected
+        violation_logger.log_violation(
+            violation_type="secret_detected",
+            blocked={
+                "file_path": "config.py",
+                "secret_type": "AWS Access Key",
+                "reason": "Gitleaks detected sensitive information"
+            },
+            context={"ide_type": "claude_code"},
+            suggestion={
+                "action": "review_and_remove_secret"
+            },
+            severity="critical"
+        )
+
+        # Test prompt_injection
+        violation_logger.log_violation(
+            violation_type="prompt_injection",
+            blocked={
+                "pattern": "ignore previous instructions",
+                "confidence": 0.95,
+                "method": "heuristic"
+            },
+            context={"ide_type": "cursor"},
+            suggestion={
+                "action": "add_allowlist_pattern"
+            },
+            severity="high"
+        )
+
+        # Verify all were logged
+        violations = violation_logger.get_recent_violations(limit=10)
+        assert len(violations) == 4
+
+        # Check each violation type
+        types = {v["violation_type"] for v in violations}
+        assert types == {"tool_permission", "directory_blocking", "secret_detected", "prompt_injection"}
+
+    finally:
+        if log_path.exists():
+            log_path.unlink()


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.
Related Issue: itdove/ai-guardian#23

## Description
This PR adds violation and audit logging capabilities to AI Guardian for tracking blocked operations.

**Changes:**
- Implemented `ViolationLogger` class to capture and log policy violations when tools or operations are blocked
- Integrated violation logging into the `ToolPolicy` enforcement layer
- Added structured logging with timestamps, operation details, policy rules violated, and context
- Comprehensive test suite for violation logging functionality
- Updated CHANGELOG.md to document the new feature

**Technical Decisions:**
- Logging is triggered at the policy enforcement point to ensure all blocked operations are captured
- Log entries include sufficient context for audit trails and debugging (tool name, parameters, policy rule, timestamp)
- Designed to be extensible for future audit reporting and analytics

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install dependencies and ensure the development environment is set up
3. Run the test suite: `pytest tests/test_violation_logger.py`
4. Manually test by configuring a policy that blocks certain tool operations
5. Trigger a blocked operation and verify that the violation is logged with correct details
6. Check log output format includes: timestamp, operation name, policy rule violated, and relevant context
7. Run the full test suite to ensure no regressions: `pytest`

### Scenarios tested
- Violation logging when a tool operation is blocked by policy
- Log entry format and content validation
- Multiple consecutive violations are logged correctly
- Integration with existing ToolPolicy enforcement mechanism

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: