### PR TITLE
itdove/ai-guardian#35: Add time-based disabling for ai-guardian security features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Time-based disabling for security features (Issue #35)
+  - Support for temporarily disabling entire security features for time-boxed periods
+  - Works for all four major features: prompt injection, tool permissions, secret scanning, and pattern server
+  - Extended format: `{"enabled": {"value": false, "disabled_until": "2026-04-13T18:00:00Z", "reason": "Debugging session"}}`
+  - Backward compatible: existing boolean `enabled` flags work unchanged
+  - Auto-re-enabling: features automatically re-enable when disable period expires
+  - Fail-safe: invalid timestamps default to permanent disable (security-first)
+  - ISO 8601 timestamp format with UTC timezone required
+  - Use cases: emergency debugging access, testing with false positives, maintenance windows
+  - Configuration fields:
+    - `prompt_injection.enabled`: Supports time-based disabling for prompt injection detection
+    - `permissions_enabled.enabled`: Supports time-based disabling for tool permissions enforcement
+    - `secret_scanning.enabled`: Supports time-based disabling for Gitleaks secret scanning
+    - `pattern_server.enabled`: Supports time-based disabling for pattern server integration
+  - Added `is_feature_enabled()` utility function to config_utils module
+  - Comprehensive test coverage for time-based feature disabling logic
+  - Logging records when features are temporarily disabled and when they auto-re-enable
+  - Security warning: disabling features reduces protection - use sparingly and only for short periods
 - Time-based expiration for permission and prompt injection allow lists (Issue #34)
   - Support both simple string patterns (permanent) and extended dict format with `valid_until` field
   - Extended format: `{"pattern": "debug-*", "valid_until": "2026-04-13T12:00:00Z"}`

--- a/ai-guardian-example.json
+++ b/ai-guardian-example.json
@@ -106,11 +106,44 @@
     "expire_after_hours": 168
   },
 
+  "permissions_enabled": {
+    "_comment": "NEW in v1.4.0: Global tool permissions enforcement control",
+    "_comment2": "Controls whether tool permissions (MCP/Skills) are enforced",
+    "_comment3": "Supports both boolean (permanent) and time-based (temporary) formats",
+    "enabled": true,
+    "_simple_format": "true (boolean - permanent enable/disable)",
+    "_extended_format_example": {
+      "value": false,
+      "disabled_until": "2026-04-13T18:00:00Z",
+      "reason": "Emergency debugging - production incident"
+    }
+  },
+
+  "secret_scanning": {
+    "_comment": "NEW in v1.4.0: Secret scanning with Gitleaks control",
+    "_comment2": "Controls whether secret scanning is performed",
+    "_comment3": "Supports both boolean (permanent) and time-based (temporary) formats",
+    "enabled": true,
+    "_simple_format": "true (boolean - permanent enable/disable)",
+    "_extended_format_example": {
+      "value": false,
+      "disabled_until": "2026-04-13T16:00:00Z",
+      "reason": "Testing with known-safe example secrets"
+    }
+  },
+
   "pattern_server": {
     "_comment": "Optional: Enhanced secret detection patterns from a pattern server",
     "_comment2": "This is an ADVANCED feature - most users should use default Gitleaks patterns",
     "_comment3": "Configure your organization's pattern server URL and authentication",
+    "_comment4": "NEW in v1.4.0: Supports time-based disabling (like other features)",
     "enabled": false,
+    "_simple_format": "false (boolean - permanent enable/disable)",
+    "_extended_format_example": {
+      "value": false,
+      "disabled_until": "2026-04-13T16:30:00Z",
+      "reason": "Maintenance window - pattern server offline"
+    },
     "url": null,
     "patterns_endpoint": "/patterns/gitleaks/8.18.1",
     "auth": {
@@ -132,7 +165,14 @@
     "_comment": "Prompt injection detection (NEW in v1.2.0)",
     "_comment2": "Protects against prompt injection attacks that try to manipulate AI behavior",
     "_comment3": "Default: Enabled with heuristic detection (local, fast, privacy-preserving)",
+    "_comment4": "NEW in v1.4.0: Supports time-based disabling for debugging/testing",
     "enabled": true,
+    "_simple_format": "true (boolean - permanent enable/disable)",
+    "_extended_format_example": {
+      "value": false,
+      "disabled_until": "2026-04-13T18:00:00Z",
+      "reason": "Testing documentation with prompt injection examples"
+    },
     "detector": "heuristic",
     "_detector_options": ["heuristic", "rebuff", "llm-guard"],
     "_detector_note": "heuristic = local patterns (default, <1ms), rebuff/llm-guard = ML-based (requires setup)",

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -19,11 +19,12 @@ import os
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional
 
-from ai_guardian.config_utils import get_config_dir
+from ai_guardian.config_utils import get_config_dir, is_feature_enabled
 
 # Import tool policy checker for MCP/Skill permissions
 try:
@@ -551,6 +552,64 @@ def _load_prompt_injection_config():
 
     except Exception as e:
         logging.debug(f"Error loading prompt injection config: {e}")
+        return None
+
+
+def _load_permissions_config():
+    """
+    Load permissions configuration from ai-guardian.json.
+
+    Returns:
+        dict: Permissions configuration or None
+    """
+    try:
+        # Try user global config first
+        config_dir = get_config_dir()
+        config_path = config_dir / "ai-guardian.json"
+
+        if not config_path.exists():
+            # Try project local config
+            config_path = Path.cwd() / ".ai-guardian.json"
+
+        if not config_path.exists():
+            return None
+
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+
+        return config.get("permissions_enabled")
+
+    except Exception as e:
+        logging.debug(f"Error loading permissions config: {e}")
+        return None
+
+
+def _load_secret_scanning_config():
+    """
+    Load secret scanning configuration from ai-guardian.json.
+
+    Returns:
+        dict: Secret scanning configuration or None
+    """
+    try:
+        # Try user global config first
+        config_dir = get_config_dir()
+        config_path = config_dir / "ai-guardian.json"
+
+        if not config_path.exists():
+            # Try project local config
+            config_path = Path.cwd() / ".ai-guardian.json"
+
+        if not config_path.exists():
+            return None
+
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+
+        return config.get("secret_scanning")
+
+    except Exception as e:
+        logging.debug(f"Error loading secret scanning config: {e}")
         return None
 
 
@@ -1115,15 +1174,26 @@ def process_hook_input():
         # Check tool permissions for PreToolUse events (MCP servers and Skills)
         if hook_event in ["pretooluse", "beforereadfile"] and HAS_TOOL_POLICY:
             try:
-                policy_checker = ToolPolicyChecker()
-                is_allowed, error_message, tool_name = policy_checker.check_tool_allowed(hook_data)
+                permissions_config = _load_permissions_config()
 
-                if not is_allowed:
-                    logging.warning(f"Tool '{tool_name}' blocked by policy")
-                    return format_response(ide_type, has_secrets=True, error_message=error_message, hook_event=hook_event)
+                # Check if permissions enforcement is enabled (supports time-based disabling)
+                if is_feature_enabled(
+                    permissions_config.get("enabled") if permissions_config else None,
+                    datetime.now(timezone.utc),
+                    default=True
+                ):
+                    policy_checker = ToolPolicyChecker()
+                    is_allowed, error_message, tool_name = policy_checker.check_tool_allowed(hook_data)
 
-                if tool_name and ide_type != IDEType.CURSOR:
-                    logging.info(f"✓ Tool '{tool_name}' allowed by policy")
+                    if not is_allowed:
+                        logging.warning(f"Tool '{tool_name}' blocked by policy")
+                        return format_response(ide_type, has_secrets=True, error_message=error_message, hook_event=hook_event)
+
+                    if tool_name and ide_type != IDEType.CURSOR:
+                        logging.info(f"✓ Tool '{tool_name}' allowed by policy")
+                elif permissions_config and ide_type != IDEType.CURSOR:
+                    # Permissions enforcement is temporarily disabled
+                    logging.info("⚠️  Tool permissions enforcement temporarily disabled")
             except Exception as e:
                 # Fail-open: if policy check fails, allow the operation
                 logging.warning(f"Tool policy check error (fail-open): {e}")
@@ -1170,44 +1240,66 @@ def process_hook_input():
         if HAS_PROMPT_INJECTION:
             try:
                 injection_config = _load_prompt_injection_config()
-                is_injection, injection_error = check_prompt_injection(
-                    content_to_scan, injection_config
-                )
 
-                if is_injection:
-                    # Prompt injection detected - block operation
-                    if ide_type != IDEType.CURSOR:
-                        logging.warning("Prompt injection detected, blocking operation")
-
-                    # Log prompt injection violation
-                    _log_prompt_injection_violation(
-                        filename,
-                        context={"ide_type": ide_type.value, "hook_event": hook_event}
+                # Check if prompt injection detection is enabled (supports time-based disabling)
+                if injection_config and is_feature_enabled(
+                    injection_config.get("enabled"),
+                    datetime.now(timezone.utc),
+                    default=True
+                ):
+                    is_injection, injection_error = check_prompt_injection(
+                        content_to_scan, injection_config
                     )
 
-                    return format_response(ide_type, has_secrets=True, error_message=injection_error, hook_event=hook_event)
+                    if is_injection:
+                        # Prompt injection detected - block operation
+                        if ide_type != IDEType.CURSOR:
+                            logging.warning("Prompt injection detected, blocking operation")
 
-                if ide_type != IDEType.CURSOR:
-                    logging.info("✓ No prompt injection detected")
+                        # Log prompt injection violation
+                        _log_prompt_injection_violation(
+                            filename,
+                            context={"ide_type": ide_type.value, "hook_event": hook_event}
+                        )
+
+                        return format_response(ide_type, has_secrets=True, error_message=injection_error, hook_event=hook_event)
+
+                    if ide_type != IDEType.CURSOR:
+                        logging.info("✓ No prompt injection detected")
+                elif injection_config and ide_type != IDEType.CURSOR:
+                    # Prompt injection detection is temporarily disabled
+                    logging.info("⚠️  Prompt injection detection temporarily disabled")
             except Exception as e:
                 # Fail-open: if prompt injection check fails, continue
                 logging.warning(f"Prompt injection check error (fail-open): {e}")
 
         # Check for secrets in the content
-        has_secrets, error_message = check_secrets_with_gitleaks(
-            content_to_scan, filename,
-            context={"ide_type": ide_type.value, "hook_event": hook_event}
-        )
+        secret_config = _load_secret_scanning_config()
 
-        if has_secrets:
-            # Secrets found - block operation
-            return format_response(ide_type, has_secrets=True, error_message=error_message, hook_event=hook_event)
+        # Check if secret scanning is enabled (supports time-based disabling)
+        if is_feature_enabled(
+            secret_config.get("enabled") if secret_config else None,
+            datetime.now(timezone.utc),
+            default=True
+        ):
+            has_secrets, error_message = check_secrets_with_gitleaks(
+                content_to_scan, filename,
+                context={"ide_type": ide_type.value, "hook_event": hook_event}
+            )
 
-        # No secrets found, allow operation
-        if hook_event == "pretooluse":
-            logging.info(f"✓ No secrets detected in file '{filename}'")
-        else:
-            logging.info("✓ No secrets detected in prompt")
+            if has_secrets:
+                # Secrets found - block operation
+                return format_response(ide_type, has_secrets=True, error_message=error_message, hook_event=hook_event)
+
+            # No secrets found, allow operation
+            if hook_event == "pretooluse":
+                logging.info(f"✓ No secrets detected in file '{filename}'")
+            else:
+                logging.info("✓ No secrets detected in prompt")
+        elif secret_config and ide_type != IDEType.CURSOR:
+            # Secret scanning is temporarily disabled
+            logging.info("⚠️  Secret scanning temporarily disabled")
+
         return format_response(ide_type, has_secrets=False, hook_event=hook_event)
 
     except json.JSONDecodeError as e:

--- a/src/ai_guardian/config_utils.py
+++ b/src/ai_guardian/config_utils.py
@@ -140,3 +140,85 @@ def is_expired(valid_until: str, current_time: Optional[datetime] = None) -> boo
 
     # Check if expired: current_time >= valid_until
     return current_time >= valid_until_dt
+
+
+def is_feature_enabled(feature_config, current_time: Optional[datetime] = None, default: bool = True) -> bool:
+    """
+    Check if a feature is enabled (not temporarily disabled).
+
+    Supports both simple boolean format (permanent) and extended object format
+    with time-based disabling.
+
+    Args:
+        feature_config: Feature configuration - can be:
+            - bool: Simple enabled/disabled (permanent)
+            - dict: Extended format with optional time-based disabling
+            - None: Use default value
+        current_time: Optional current time for testing (defaults to now in UTC)
+        default: Default value if config is None or missing (default: True)
+
+    Returns:
+        bool: True if feature should be active, False if disabled
+
+    Examples:
+        Simple boolean format (backward compatible):
+        >>> is_feature_enabled(True)
+        True
+
+        >>> is_feature_enabled(False)
+        False
+
+        Extended format without time-based disabling:
+        >>> is_feature_enabled({"value": True})
+        True
+
+        Extended format with time-based disabling (active):
+        >>> config = {"value": False, "disabled_until": "2099-12-31T23:59:59Z"}
+        >>> is_feature_enabled(config)  # Still disabled (future date)
+        False
+
+        Extended format with expired disable period (auto-enabled):
+        >>> config = {"value": False, "disabled_until": "2020-01-01T00:00:00Z"}
+        >>> is_feature_enabled(config)  # Auto-enabled (past date)
+        True
+
+        Missing config uses default:
+        >>> is_feature_enabled(None)
+        True
+
+        >>> is_feature_enabled(None, default=False)
+        False
+    """
+    # Handle None - use default
+    if feature_config is None:
+        return default
+
+    # Simple boolean format (backward compatible)
+    if isinstance(feature_config, bool):
+        return feature_config
+
+    # Extended format with optional time-based disabling
+    if isinstance(feature_config, dict):
+        # Get the enabled value (default to True if missing)
+        enabled_value = feature_config.get("value", default)
+
+        # If currently disabled, check if it should be auto-re-enabled
+        if not enabled_value:
+            disabled_until = feature_config.get("disabled_until")
+            if disabled_until:
+                # Check if disable period has expired
+                if is_expired(disabled_until, current_time):
+                    # Temporary disable period has expired - re-enable
+                    logger.info("Feature auto-enabled (disable period expired)")
+                    return True
+                else:
+                    # Still within disable period
+                    logger.debug("Feature disabled (within disable period)")
+                    return False
+
+        # Return the enabled value
+        return enabled_value
+
+    # Unknown format - fail-safe to default
+    logger.warning(f"Unknown feature config format: {type(feature_config)}, using default: {default}")
+    return default

--- a/src/ai_guardian/pattern_server.py
+++ b/src/ai_guardian/pattern_server.py
@@ -13,8 +13,11 @@ import json
 import logging
 import os
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Tuple
+
+from ai_guardian.config_utils import is_feature_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +47,8 @@ class PatternServerClient:
         Args:
             config: Pattern server configuration from ai-guardian.json
         """
-        self.enabled = config.get("enabled", False)
+        # Store enabled config (supports both boolean and time-based formats)
+        self.enabled_config = config.get("enabled", False)
         self.base_url = config.get("url")
         self.patterns_endpoint = config.get("patterns_endpoint", "/patterns/gitleaks/8.18.1")
 
@@ -66,7 +70,9 @@ class PatternServerClient:
         Returns:
             Path to patterns file, or None if unavailable
         """
-        if not self.enabled:
+        # Check if pattern server is enabled (supports time-based disabling)
+        if not is_feature_enabled(self.enabled_config, datetime.now(timezone.utc), default=False):
+            logger.debug("Pattern server is disabled or temporarily disabled")
             return None
 
         if not HAS_REQUESTS:

--- a/tests/test_ai_guardian.py
+++ b/tests/test_ai_guardian.py
@@ -911,6 +911,216 @@ Yyv2dJ5Y2LtZ7YywIDAQABAoIBADCNMXk8y5K6lVZMsEHHWpdGIyDyUPsryXctAJAc
         self.assertEqual(response["exit_code"], 2)
         self.assertIsNone(response["output"])
 
+    @patch('ai_guardian._load_prompt_injection_config')
+    @patch('ai_guardian.check_prompt_injection')
+    @patch('ai_guardian.check_secrets_with_gitleaks')
+    def test_prompt_injection_time_based_disabled(self, mock_check_secrets, mock_check_injection, mock_load_config):
+        """Test prompt injection detection temporarily disabled via time-based config"""
+        from datetime import datetime, timezone
+
+        # Configure prompt injection as temporarily disabled (future expiration)
+        mock_load_config.return_value = {
+            "enabled": {
+                "value": False,
+                "disabled_until": "2099-12-31T23:59:59Z",
+                "reason": "Testing prompt injection examples"
+            },
+            "detector": "heuristic"
+        }
+
+        mock_check_secrets.return_value = (False, None)
+        # Injection check shouldn't be called since feature is disabled
+        mock_check_injection.return_value = (True, "Injection detected")
+
+        hook_input = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt"
+        })
+
+        with patch('sys.stdin', StringIO(hook_input)):
+            response = ai_guardian.process_hook_input()
+
+        # Should allow (not block) since prompt injection is disabled
+        self.assertEqual(response["exit_code"], 0)
+        # Injection check should not be called
+        mock_check_injection.assert_not_called()
+
+    @patch('ai_guardian._load_prompt_injection_config')
+    @patch('ai_guardian.check_prompt_injection')
+    @patch('ai_guardian.check_secrets_with_gitleaks')
+    def test_prompt_injection_time_based_expired_auto_enabled(self, mock_check_secrets, mock_check_injection, mock_load_config):
+        """Test prompt injection detection auto-enabled after disable period expires"""
+        from datetime import datetime, timezone
+
+        # Configure prompt injection with expired disable period (past date)
+        mock_load_config.return_value = {
+            "enabled": {
+                "value": False,
+                "disabled_until": "2020-01-01T00:00:00Z",  # Past date
+                "reason": "Expired disable"
+            },
+            "detector": "heuristic"
+        }
+
+        mock_check_secrets.return_value = (False, None)
+        mock_check_injection.return_value = (True, "Injection detected")
+
+        hook_input = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt"
+        })
+
+        with patch('sys.stdin', StringIO(hook_input)):
+            response = ai_guardian.process_hook_input()
+
+        # Should block since prompt injection is auto-enabled (expired disable)
+        self.assertEqual(response["exit_code"], 2)
+        # Injection check should be called
+        mock_check_injection.assert_called_once()
+
+    @patch('ai_guardian._load_permissions_config')
+    @patch('ai_guardian.ToolPolicyChecker')
+    @patch('ai_guardian.check_secrets_with_gitleaks')
+    def test_permissions_time_based_disabled(self, mock_check_secrets, mock_policy_checker_class, mock_load_config):
+        """Test tool permissions temporarily disabled via time-based config"""
+        from datetime import datetime, timezone
+
+        # Configure permissions as temporarily disabled
+        mock_load_config.return_value = {
+            "enabled": {
+                "value": False,
+                "disabled_until": "2099-12-31T23:59:59Z",
+                "reason": "Emergency debugging"
+            }
+        }
+
+        mock_check_secrets.return_value = (False, None)
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("test content")
+            temp_path = f.name
+
+        try:
+            hook_input = json.dumps({
+                "hook_event_name": "PreToolUse",
+                "input": {
+                    "tool_name": "Read",
+                    "file_path": temp_path
+                }
+            })
+
+            with patch('sys.stdin', StringIO(hook_input)):
+                response = ai_guardian.process_hook_input()
+
+            # Should allow (not check permissions) since enforcement is disabled
+            self.assertEqual(response["exit_code"], 0)
+            # Policy checker should not be instantiated
+            mock_policy_checker_class.assert_not_called()
+        finally:
+            os.unlink(temp_path)
+
+    @patch('ai_guardian._load_secret_scanning_config')
+    @patch('ai_guardian.check_secrets_with_gitleaks')
+    def test_secret_scanning_time_based_disabled(self, mock_check_secrets, mock_load_config):
+        """Test secret scanning temporarily disabled via time-based config"""
+        from datetime import datetime, timezone
+
+        # Configure secret scanning as temporarily disabled
+        mock_load_config.return_value = {
+            "enabled": {
+                "value": False,
+                "disabled_until": "2099-12-31T23:59:59Z",
+                "reason": "Testing with known-safe example secrets"
+            }
+        }
+
+        # Even if check_secrets would find secrets, it shouldn't be called
+        mock_check_secrets.return_value = (True, "Secret detected")
+
+        hook_input = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt with ghp_token123"
+        })
+
+        with patch('sys.stdin', StringIO(hook_input)):
+            response = ai_guardian.process_hook_input()
+
+        # Should allow since secret scanning is disabled
+        self.assertEqual(response["exit_code"], 0)
+        # Secret check should not be called
+        mock_check_secrets.assert_not_called()
+
+    @patch('ai_guardian._load_secret_scanning_config')
+    @patch('ai_guardian.check_secrets_with_gitleaks')
+    def test_secret_scanning_time_based_expired_auto_enabled(self, mock_check_secrets, mock_load_config):
+        """Test secret scanning auto-enabled after disable period expires"""
+        from datetime import datetime, timezone
+
+        # Configure secret scanning with expired disable period
+        mock_load_config.return_value = {
+            "enabled": {
+                "value": False,
+                "disabled_until": "2020-01-01T00:00:00Z",  # Past date
+                "reason": "Expired disable"
+            }
+        }
+
+        mock_check_secrets.return_value = (True, "Secret detected")
+
+        hook_input = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt"
+        })
+
+        with patch('sys.stdin', StringIO(hook_input)):
+            response = ai_guardian.process_hook_input()
+
+        # Should block since secret scanning is auto-enabled
+        self.assertEqual(response["exit_code"], 2)
+        # Secret check should be called
+        mock_check_secrets.assert_called_once()
+
+    @patch('ai_guardian._load_prompt_injection_config')
+    @patch('ai_guardian._load_secret_scanning_config')
+    @patch('ai_guardian.check_prompt_injection')
+    @patch('ai_guardian.check_secrets_with_gitleaks')
+    def test_multiple_features_different_states(self, mock_check_secrets, mock_check_injection, mock_secret_config, mock_injection_config):
+        """Test multiple features with different enable/disable states"""
+        from datetime import datetime, timezone
+
+        # Prompt injection: enabled (boolean)
+        mock_injection_config.return_value = {
+            "enabled": True,
+            "detector": "heuristic"
+        }
+
+        # Secret scanning: temporarily disabled
+        mock_secret_config.return_value = {
+            "enabled": {
+                "value": False,
+                "disabled_until": "2099-12-31T23:59:59Z"
+            }
+        }
+
+        mock_check_injection.return_value = (False, None)
+        mock_check_secrets.return_value = (True, "Secret detected")
+
+        hook_input = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt"
+        })
+
+        with patch('sys.stdin', StringIO(hook_input)):
+            response = ai_guardian.process_hook_input()
+
+        # Should allow (prompt injection check runs and passes, secret scanning disabled)
+        self.assertEqual(response["exit_code"], 0)
+        # Injection check should be called (enabled)
+        mock_check_injection.assert_called_once()
+        # Secret check should NOT be called (disabled)
+        mock_check_secrets.assert_not_called()
+
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -5,7 +5,7 @@ Unit tests for config_utils module
 import unittest
 from datetime import datetime, timezone, timedelta
 
-from ai_guardian.config_utils import parse_iso8601, is_expired
+from ai_guardian.config_utils import parse_iso8601, is_expired, is_feature_enabled
 
 
 class ConfigUtilsTest(unittest.TestCase):
@@ -142,6 +142,169 @@ class ConfigUtilsTest(unittest.TestCase):
         # Afternoon: debug access expired
         afternoon = datetime(2026, 4, 13, 14, 30, 0, tzinfo=timezone.utc)
         self.assertTrue(is_expired(debug_expires, afternoon))
+
+
+class IsFeatureEnabledTest(unittest.TestCase):
+    """Test suite for is_feature_enabled function"""
+
+    def test_simple_boolean_true(self):
+        """Test simple boolean format: True"""
+        self.assertTrue(is_feature_enabled(True))
+
+    def test_simple_boolean_false(self):
+        """Test simple boolean format: False"""
+        self.assertFalse(is_feature_enabled(False))
+
+    def test_none_config_uses_default_true(self):
+        """Test None config uses default value (True)"""
+        self.assertTrue(is_feature_enabled(None, default=True))
+
+    def test_none_config_uses_default_false(self):
+        """Test None config uses default value (False)"""
+        self.assertFalse(is_feature_enabled(None, default=False))
+
+    def test_dict_format_enabled_true(self):
+        """Test dict format with value=True"""
+        config = {"value": True}
+        self.assertTrue(is_feature_enabled(config))
+
+    def test_dict_format_enabled_false(self):
+        """Test dict format with value=False (permanent disable)"""
+        config = {"value": False}
+        self.assertFalse(is_feature_enabled(config))
+
+    def test_dict_format_missing_value_uses_default(self):
+        """Test dict format with missing value field uses default"""
+        config = {}
+        self.assertTrue(is_feature_enabled(config, default=True))
+        self.assertFalse(is_feature_enabled(config, default=False))
+
+    def test_time_based_disabled_not_expired(self):
+        """Test time-based disable that hasn't expired yet"""
+        current_time = datetime(2026, 4, 13, 11, 0, 0, tzinfo=timezone.utc)
+        config = {
+            "value": False,
+            "disabled_until": "2026-04-13T18:00:00Z"
+        }
+        # Still disabled (before expiration)
+        self.assertFalse(is_feature_enabled(config, current_time))
+
+    def test_time_based_disabled_expired_auto_enabled(self):
+        """Test time-based disable that has expired (auto-enabled)"""
+        current_time = datetime(2026, 4, 13, 19, 0, 0, tzinfo=timezone.utc)
+        config = {
+            "value": False,
+            "disabled_until": "2026-04-13T18:00:00Z"
+        }
+        # Auto-enabled (after expiration)
+        self.assertTrue(is_feature_enabled(config, current_time))
+
+    def test_time_based_disabled_at_boundary(self):
+        """Test time-based disable exactly at expiration boundary"""
+        current_time = datetime(2026, 4, 13, 18, 0, 0, tzinfo=timezone.utc)
+        config = {
+            "value": False,
+            "disabled_until": "2026-04-13T18:00:00Z"
+        }
+        # Auto-enabled (at expiration time)
+        self.assertTrue(is_feature_enabled(config, current_time))
+
+    def test_enabled_true_with_disabled_until_ignored(self):
+        """Test that disabled_until is ignored when value=True"""
+        current_time = datetime(2026, 4, 13, 11, 0, 0, tzinfo=timezone.utc)
+        config = {
+            "value": True,
+            "disabled_until": "2026-04-13T18:00:00Z"
+        }
+        # Enabled, disabled_until doesn't apply
+        self.assertTrue(is_feature_enabled(config, current_time))
+
+    def test_disabled_false_without_disabled_until(self):
+        """Test permanent disable (value=False without disabled_until)"""
+        config = {"value": False}
+        # Permanently disabled
+        self.assertFalse(is_feature_enabled(config))
+
+    def test_invalid_disabled_until_treats_as_permanent(self):
+        """Test invalid disabled_until timestamp treats as permanent disable"""
+        config = {
+            "value": False,
+            "disabled_until": "invalid-timestamp"
+        }
+        # Invalid timestamp - treats as permanent disable (fail-safe)
+        self.assertFalse(is_feature_enabled(config))
+
+    def test_empty_disabled_until_treats_as_permanent(self):
+        """Test empty disabled_until field treats as permanent disable"""
+        config = {
+            "value": False,
+            "disabled_until": ""
+        }
+        # Empty timestamp - treats as permanent disable
+        self.assertFalse(is_feature_enabled(config))
+
+    def test_unknown_format_uses_default(self):
+        """Test unknown config format falls back to default"""
+        config = "unknown-format"
+        self.assertTrue(is_feature_enabled(config, default=True))
+        self.assertFalse(is_feature_enabled(config, default=False))
+
+    def test_real_world_emergency_access(self):
+        """Test real-world scenario: emergency access for 30 minutes"""
+        disable_start = datetime(2026, 4, 13, 14, 0, 0, tzinfo=timezone.utc)
+        disable_end = datetime(2026, 4, 13, 14, 30, 0, tzinfo=timezone.utc)
+
+        config = {
+            "value": False,
+            "disabled_until": "2026-04-13T14:30:00Z",
+            "reason": "Emergency debugging - production incident"
+        }
+
+        # During emergency window - disabled
+        emergency_time = datetime(2026, 4, 13, 14, 15, 0, tzinfo=timezone.utc)
+        self.assertFalse(is_feature_enabled(config, emergency_time))
+
+        # After emergency window - auto-enabled
+        after_emergency = datetime(2026, 4, 13, 14, 45, 0, tzinfo=timezone.utc)
+        self.assertTrue(is_feature_enabled(config, after_emergency))
+
+    def test_real_world_maintenance_window(self):
+        """Test real-world scenario: maintenance window (1 hour)"""
+        config = {
+            "value": False,
+            "disabled_until": "2026-04-13T16:00:00Z",
+            "reason": "Maintenance window - testing with example secrets"
+        }
+
+        # During maintenance - disabled
+        maintenance_time = datetime(2026, 4, 13, 15, 30, 0, tzinfo=timezone.utc)
+        self.assertFalse(is_feature_enabled(config, maintenance_time))
+
+        # After maintenance - auto-enabled
+        after_maintenance = datetime(2026, 4, 13, 17, 0, 0, tzinfo=timezone.utc)
+        self.assertTrue(is_feature_enabled(config, after_maintenance))
+
+    def test_multiple_features_different_expiration(self):
+        """Test multiple features with different expiration times"""
+        current_time = datetime(2026, 4, 13, 15, 30, 0, tzinfo=timezone.utc)
+
+        # Feature 1: expired (should be enabled)
+        feature1_config = {
+            "value": False,
+            "disabled_until": "2026-04-13T15:00:00Z"
+        }
+        self.assertTrue(is_feature_enabled(feature1_config, current_time))
+
+        # Feature 2: not expired (still disabled)
+        feature2_config = {
+            "value": False,
+            "disabled_until": "2026-04-13T16:00:00Z"
+        }
+        self.assertFalse(is_feature_enabled(feature2_config, current_time))
+
+        # Feature 3: permanently enabled
+        feature3_config = {"value": True}
+        self.assertTrue(is_feature_enabled(feature3_config, current_time))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
Related Issue: itdove/ai-guardian#35

## Description
This PR adds time-based disabling functionality for ai-guardian security features, allowing security checks to be temporarily disabled for a specified duration.

**Changes include:**
- Added time-based disable configuration support in `config_utils.py` with expiration tracking
- Integrated disable functionality into the pattern server to respect time-based exemptions
- Updated configuration schema to support `disable_until` timestamp fields
- Added example configuration in `ai-guardian-example.json` demonstrating the feature
- Comprehensive test coverage for time-based disable logic in both unit and integration tests
- Updated CHANGELOG.md with feature documentation

The implementation allows users to disable specific security features until a specified timestamp, after which the features automatically re-enable. This is useful for temporary exemptions during development or troubleshooting without permanently disabling security controls.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Review the example configuration in `ai-guardian-example.json` for the `disable_until` configuration format
3. Run the test suite: `pytest tests/test_config_utils.py tests/test_ai_guardian.py -v`
4. Verify time-based disable logic:
   - Configure a security feature with a future `disable_until` timestamp
   - Confirm the feature is disabled while the timestamp is in the future
   - Advance system time or wait for expiration and verify the feature re-enables
5. Test invalid configurations (past timestamps, malformed dates) to ensure proper error handling

### Scenarios tested
- Security features disabled with future expiration timestamps remain disabled until expiration
- Security features with past or expired `disable_until` timestamps are active
- Configuration validation properly handles missing or invalid timestamp formats
- Multiple security features can have independent disable schedules
- Expiration logic correctly handles timezone-aware timestamps

## Deployment considerations
- [x] This code change is ready for deployment on its own

The feature is backward compatible. Existing configurations without `disable_until` fields will continue to work unchanged. No migration or configuration updates are required for existing deployments.