### PR TITLE
itdove/ai-guardian#45: Add IMMUTABLE_DENY_PATTERNS for PowerShell tool to prevent Windows bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- PowerShell tool protection for Windows users (Issue #45)
+  - Added IMMUTABLE_DENY_PATTERNS for PowerShell tool to prevent Windows bypass
+  - Blocks PowerShell cmdlets: Remove-Item, Move-Item, Rename-Item, Set-Content, Clear-Content, Out-File, Copy-Item
+  - Blocks PowerShell aliases: del, erase, rm, mv, move, ren, copy, rmdir
+  - Blocks PowerShell redirections (>, >>)
+  - Protects ai-guardian config files, IDE hook files, package source code, and .ai-read-deny markers
+  - Supports both Unix-style paths (/) and Windows-style paths (\) for cross-platform compatibility
+  - Updated _extract_check_value() to handle PowerShell commands
+  - Comprehensive test coverage (27 test cases in test_powershell_protection.py)
+  - Defense in depth: prevents bypass of self-protection on Windows systems with PowerShell tool enabled
 - Protection for .ai-read-deny marker files (Issue #41)
   - AI agents can no longer remove or modify `.ai-read-deny` marker files
   - Prevents bypass of directory protection by deleting marker files

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -112,6 +112,70 @@ IMMUTABLE_DENY_PATTERNS = {
         "*chattr*.ai-read-deny*",      # Block: chattr .ai-read-deny
         "*vim*.ai-read-deny*",         # Block: vim .ai-read-deny
         "*nano*.ai-read-deny*",        # Block: nano .ai-read-deny
+    ],
+
+    "PowerShell": [
+        # Protect ai-guardian config files
+        "*Remove-Item*ai-guardian*", "*Remove-Item*ai_guardian*",
+        "*Move-Item*ai-guardian*", "*Move-Item*ai_guardian*",
+        "*Rename-Item*ai-guardian*", "*Rename-Item*ai_guardian*",
+        "*Set-Content*ai-guardian*", "*Set-Content*ai_guardian*",
+        "*Clear-Content*ai-guardian*", "*Clear-Content*ai_guardian*",
+        "*Out-File*ai-guardian*", "*Out-File*ai_guardian*",
+        "*Copy-Item*ai-guardian*", "*Copy-Item*ai_guardian*",
+
+        # Protect IDE hook files (Unix paths)
+        "*Remove-Item*.claude/settings.json*", "*Remove-Item*.cursor/hooks.json*",
+        "*Remove-Item*Claude/settings.json*", "*Remove-Item*Cursor/hooks.json*",
+        "*Move-Item*.claude/settings.json*", "*Move-Item*.cursor/hooks.json*",
+        "*Move-Item*Claude/settings.json*", "*Move-Item*Cursor/hooks.json*",
+        "*Rename-Item*.claude/settings.json*", "*Rename-Item*.cursor/hooks.json*",
+        "*Rename-Item*Claude/settings.json*", "*Rename-Item*Cursor/hooks.json*",
+        "*Set-Content*.claude/settings.json*", "*Set-Content*.cursor/hooks.json*",
+        "*Set-Content*Claude/settings.json*", "*Set-Content*Cursor/hooks.json*",
+        "*Clear-Content*.claude/settings.json*", "*Clear-Content*.cursor/hooks.json*",
+        "*Clear-Content*Claude/settings.json*", "*Clear-Content*Cursor/hooks.json*",
+        "*Out-File*.claude/settings.json*", "*Out-File*.cursor/hooks.json*",
+        "*Out-File*Claude/settings.json*", "*Out-File*Cursor/hooks.json*",
+
+        # Protect IDE hook files (Windows backslash paths)
+        "*Remove-Item*Claude\\settings.json*", "*Remove-Item*Cursor\\hooks.json*",
+        "*Move-Item*Claude\\settings.json*", "*Move-Item*Cursor\\hooks.json*",
+        "*Rename-Item*Claude\\settings.json*", "*Rename-Item*Cursor\\hooks.json*",
+        "*Set-Content*Claude\\settings.json*", "*Set-Content*Cursor\\settings.json*",
+        "*Clear-Content*Claude\\settings.json*", "*Clear-Content*Cursor\\hooks.json*",
+        "*Out-File*Claude\\settings.json*", "*Out-File*Cursor\\hooks.json*",
+
+        # Protect ai-guardian package source
+        "*Remove-Item*ai_guardian/*", "*Remove-Item*ai_guardian\\*",
+        "*Set-Content*ai_guardian/*", "*Set-Content*ai_guardian\\*",
+        "*Clear-Content*ai_guardian/*", "*Clear-Content*ai_guardian\\*",
+        "*Out-File*ai_guardian/*", "*Out-File*ai_guardian\\*",
+
+        # Protect against PowerShell redirections
+        "*>*ai-guardian*", "*>>*ai-guardian*",
+        "*>*.claude/settings.json*", "*>*.cursor/hooks.json*",
+        "*>*Claude/settings.json*", "*>*Cursor/hooks.json*",
+
+        # Protect .ai-read-deny marker files from PowerShell manipulation
+        "*Remove-Item*.ai-read-deny*",
+        "*Move-Item*.ai-read-deny*",
+        "*Rename-Item*.ai-read-deny*",
+        "*Set-Content*.ai-read-deny*",
+        "*Clear-Content*.ai-read-deny*",
+        "*Out-File*.ai-read-deny*",
+        "*Copy-Item*.ai-read-deny*",
+        "*>*.ai-read-deny*",
+
+        # PowerShell aliases (del, erase, rm, mv, etc.)
+        "*del *ai-guardian*", "*erase *ai-guardian*",
+        "*rm *ai-guardian*", "*rmdir *ai-guardian*",
+        "*mv *ai-guardian*", "*move *ai-guardian*",
+        "*ren *ai-guardian*", "*copy *ai-guardian*",
+        "*rm *.claude/settings.json*", "*del *.claude/settings.json*",
+        "*rm *.cursor/hooks.json*", "*del *.cursor/hooks.json*",
+        "*rm *.ai-read-deny*", "*del *.ai-read-deny*",
+        "*mv *.ai-read-deny*", "*move *.ai-read-deny*",
     ]
 }
 
@@ -498,8 +562,8 @@ class ToolPolicyChecker:
             skill = tool_input.get("skill")
             return skill if skill else None
 
-        # Bash/Shell: extract command from input
-        if matcher == "Bash" or matcher == "Shell":
+        # Bash/Shell/PowerShell: extract command from input
+        if matcher == "Bash" or matcher == "Shell" or matcher == "PowerShell":
             command = tool_input.get("command")
             return command if command else None
 
@@ -624,8 +688,11 @@ class ToolPolicyChecker:
         Returns:
             str: Formatted error message
         """
-        # Check if this is a .ai-read-deny marker file
-        is_marker_file = file_path.endswith('.ai-read-deny') or '/.ai-read-deny' in file_path
+        # Check if this is a .ai-read-deny marker file (check both Unix and Windows paths)
+        is_marker_file = (file_path.endswith('.ai-read-deny') or
+                         '/.ai-read-deny' in file_path or
+                         '\\.ai-read-deny' in file_path or
+                         '.ai-read-deny' in file_path)
 
         base_message = (
             f"\n{'='*70}\n"

--- a/tests/test_powershell_protection.py
+++ b/tests/test_powershell_protection.py
@@ -1,0 +1,495 @@
+"""
+Unit tests for PowerShell tool self-protection (Issue #45)
+
+Tests the IMMUTABLE_DENY_PATTERNS for PowerShell tool that protect:
+- ai-guardian configuration files
+- IDE hook configuration files (Claude, Cursor)
+- ai-guardian package source code
+- .ai-read-deny marker files
+"""
+
+import json
+from unittest import TestCase
+from ai_guardian.tool_policy import ToolPolicyChecker
+
+
+class PowerShellProtectionTest(TestCase):
+    """Test suite for PowerShell self-protection feature"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        # Create policy checker with empty config (no user-configured permissions)
+        # This ensures we're only testing the immutable deny patterns
+        self.policy_checker = ToolPolicyChecker(config={"permissions": []})
+
+    # ========================================================================
+    # Test: PowerShell cannot modify ai-guardian config files
+    # ========================================================================
+
+    def test_powershell_blocks_remove_item_config(self):
+        """PowerShell Remove-Item blocked for ai-guardian.json"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item ~/.config/ai-guardian/ai-guardian.json -Force"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Remove-Item on config should be blocked")
+        self.assertIsNotNone(error_msg, "Error message should be provided")
+        self.assertIn("CRITICAL FILE PROTECTED", error_msg)
+
+    def test_powershell_blocks_set_content_config(self):
+        """PowerShell Set-Content blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path ~/.config/ai-guardian/ai-guardian.json -Value '{}'"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Set-Content on config should be blocked")
+        self.assertIn("CRITICAL FILE PROTECTED", error_msg)
+
+    def test_powershell_blocks_clear_content_config(self):
+        """PowerShell Clear-Content blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Clear-Content -Path C:\\Users\\user\\.config\\ai-guardian\\ai-guardian.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Clear-Content on config should be blocked")
+
+    def test_powershell_blocks_move_item_config(self):
+        """PowerShell Move-Item blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Move-Item ai-guardian.json ai-guardian.json.bak"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Move-Item on config should be blocked")
+
+    def test_powershell_blocks_rename_item_config(self):
+        """PowerShell Rename-Item blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Rename-Item ai-guardian.json old-config.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Rename-Item on config should be blocked")
+
+    def test_powershell_blocks_out_file_config(self):
+        """PowerShell Out-File blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Get-Content empty.json | Out-File -FilePath ai-guardian.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Out-File on config should be blocked")
+
+    def test_powershell_blocks_copy_item_config(self):
+        """PowerShell Copy-Item blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Copy-Item empty.json ai-guardian.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Copy-Item on config should be blocked")
+
+    # ========================================================================
+    # Test: PowerShell cannot modify IDE hook files
+    # ========================================================================
+
+    def test_powershell_blocks_remove_item_claude_settings(self):
+        """PowerShell Remove-Item blocked for Claude settings"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item ~/.claude/settings.json -Force"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Remove-Item on Claude settings should be blocked")
+        self.assertIn("IDE hook configuration", error_msg)
+
+    def test_powershell_blocks_set_content_cursor_hooks(self):
+        """PowerShell Set-Content blocked for Cursor hooks"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path ~/.cursor/hooks.json -Value '{}'"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Set-Content on Cursor hooks should be blocked")
+
+    def test_powershell_blocks_clear_content_windows_claude(self):
+        """PowerShell Clear-Content blocked for Windows Claude settings"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Clear-Content C:\\Users\\user\\AppData\\Roaming\\Claude\\settings.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Clear-Content on Windows Claude settings should be blocked")
+
+    def test_powershell_blocks_move_item_cursor_hooks(self):
+        """PowerShell Move-Item blocked for Cursor hooks"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Move-Item ~/.cursor/hooks.json ~/.cursor/hooks.json.bak"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Move-Item on Cursor hooks should be blocked")
+
+    # ========================================================================
+    # Test: PowerShell cannot modify package source
+    # ========================================================================
+
+    def test_powershell_blocks_remove_item_package_source(self):
+        """PowerShell Remove-Item blocked for package source"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item C:\\Python\\Lib\\site-packages\\ai_guardian\\tool_policy.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Remove-Item on package source should be blocked")
+        self.assertIn("package source code", error_msg)
+
+    def test_powershell_blocks_set_content_package_source(self):
+        """PowerShell Set-Content blocked for package source"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path /usr/lib/python3.12/site-packages/ai_guardian/__main__.py -Value ''"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Set-Content on package source should be blocked")
+
+    # ========================================================================
+    # Test: PowerShell redirections blocked
+    # ========================================================================
+
+    def test_powershell_blocks_redirect_config(self):
+        """PowerShell redirect (>) blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "echo '{}' > ~/.config/ai-guardian/ai-guardian.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell redirect to config should be blocked")
+
+    def test_powershell_blocks_append_redirect_claude_settings(self):
+        """PowerShell append redirect (>>) blocked for Claude settings"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "echo 'data' >> ~/.claude/settings.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell append redirect to Claude settings should be blocked")
+
+    # ========================================================================
+    # Test: PowerShell aliases blocked
+    # ========================================================================
+
+    def test_powershell_blocks_del_alias_config(self):
+        """PowerShell del alias blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "del ai-guardian.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell del alias on config should be blocked")
+
+    def test_powershell_blocks_rm_alias_claude_settings(self):
+        """PowerShell rm alias blocked for Claude settings"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "rm ~/.claude/settings.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell rm alias on Claude settings should be blocked")
+
+    def test_powershell_blocks_move_alias_config(self):
+        """PowerShell move alias blocked for ai-guardian config"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "move ai-guardian.json backup.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell move alias on config should be blocked")
+
+    # ========================================================================
+    # Test: PowerShell cannot modify .ai-read-deny marker files
+    # ========================================================================
+
+    def test_powershell_blocks_remove_item_ai_read_deny(self):
+        """PowerShell Remove-Item blocked for .ai-read-deny"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item C:\\secrets\\.ai-read-deny -Force"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Remove-Item on .ai-read-deny should be blocked")
+        self.assertIn("Directory protection marker", error_msg)
+
+    def test_powershell_blocks_move_item_ai_read_deny(self):
+        """PowerShell Move-Item blocked for .ai-read-deny"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Move-Item /home/user/secrets/.ai-read-deny /tmp/backup"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Move-Item on .ai-read-deny should be blocked")
+
+    def test_powershell_blocks_set_content_ai_read_deny(self):
+        """PowerShell Set-Content blocked for .ai-read-deny"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path .ai-read-deny -Value 'test'"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Set-Content on .ai-read-deny should be blocked")
+
+    def test_powershell_blocks_clear_content_ai_read_deny(self):
+        """PowerShell Clear-Content blocked for .ai-read-deny"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Clear-Content /var/sensitive/.ai-read-deny"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Clear-Content on .ai-read-deny should be blocked")
+
+    def test_powershell_blocks_redirect_ai_read_deny(self):
+        """PowerShell redirect blocked for .ai-read-deny"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "echo '' > /home/user/secrets/.ai-read-deny"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell redirect to .ai-read-deny should be blocked")
+
+    def test_powershell_blocks_rm_alias_ai_read_deny(self):
+        """PowerShell rm alias blocked for .ai-read-deny"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "rm .ai-read-deny"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell rm alias on .ai-read-deny should be blocked")
+
+    # ========================================================================
+    # Test: Legitimate PowerShell commands allowed
+    # ========================================================================
+
+    def test_powershell_allows_normal_commands(self):
+        """Legitimate PowerShell commands should be allowed"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Get-ChildItem C:\\Users\\user\\Documents"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "Normal PowerShell commands should be allowed")
+        self.assertIsNone(error_msg, "No error message for allowed operation")
+
+    def test_powershell_allows_remove_normal_files(self):
+        """PowerShell Remove-Item allowed for normal files"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item C:\\Users\\user\\Documents\\temp.txt"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "PowerShell Remove-Item on normal files should be allowed")
+
+    def test_powershell_allows_set_content_normal_files(self):
+        """PowerShell Set-Content allowed for normal files"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path C:\\project\\README.md -Value 'Hello World'"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "PowerShell Set-Content on normal files should be allowed")
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://github.com/itdove/ai-guardian/issues/45>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR adds immutable deny patterns for the PowerShell tool to prevent Windows-based bypass vulnerabilities. The implementation introduces `IMMUTABLE_DENY_PATTERNS` to the tool policy framework, specifically targeting PowerShell command execution that could be used to circumvent existing security controls on Windows systems.

**Technical changes:**
- Added PowerShell-specific immutable deny patterns to `tool_policy.py` to block dangerous command patterns
- Implemented comprehensive test coverage in `test_powershell_protection.py` to validate the protection mechanism
- Updated CHANGELOG.md to document this security enhancement

**Motivation:**
This change addresses a potential security gap where PowerShell tools could be exploited to bypass existing guardrails on Windows environments. By adding immutable deny patterns, we ensure these protections cannot be overridden.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the new PowerShell protection test suite: `pytest tests/test_powershell_protection.py -v`
3. Verify all test cases pass, including bypass attempt scenarios
4. Run the full test suite to ensure no regressions: `pytest`
5. Manually test PowerShell tool invocation with various command patterns to confirm deny patterns are enforced
6. Verify that legitimate PowerShell commands still function as expected

### Scenarios tested
- PowerShell commands matching deny patterns are correctly blocked
- Immutable deny patterns cannot be overridden by user configuration
- Legitimate PowerShell tool usage remains functional
- Edge cases and bypass attempts are properly rejected
- Integration with existing tool policy framework

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: