### PR TITLE
itdove/ai-guardian#47: Refine IMMUTABLE_DENY_PATTERNS for ai_guardian package protection to reduce false positives

### DIFF
--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -48,8 +48,9 @@ IMMUTABLE_DENY_PATTERNS = {
         "*/Cursor/hooks.json",        # Windows
 
         # Protect ai-guardian package (self-protection)
-        "*/ai_guardian/*",
-        "*/site-packages/ai_guardian/*",
+        "*/site-packages/ai_guardian/*",           # Installed package
+        "*/ai-guardian/src/ai_guardian/*",         # Source repo (with hyphen)
+        "*/ai-guardian/ai_guardian/*",             # Alternative source layout
 
         # Protect .ai-read-deny marker files (directory protection)
         "*/.ai-read-deny",
@@ -66,8 +67,9 @@ IMMUTABLE_DENY_PATTERNS = {
         "*/.cursor/hooks.json",
         "*/Claude/settings.json",
         "*/Cursor/hooks.json",
-        "*/ai_guardian/*",
-        "*/site-packages/ai_guardian/*",
+        "*/site-packages/ai_guardian/*",           # Installed package
+        "*/ai-guardian/src/ai_guardian/*",         # Source repo (with hyphen)
+        "*/ai-guardian/ai_guardian/*",             # Alternative source layout
 
         # Protect .ai-read-deny marker files (directory protection)
         "*/.ai-read-deny",
@@ -76,8 +78,10 @@ IMMUTABLE_DENY_PATTERNS = {
 
     "Bash": [
         # Block commands that could modify protected files
-        "*sed*ai-guardian*", "*sed*ai_guardian*",
-        "*awk*ai-guardian*", "*awk*ai_guardian*",
+        "*sed*ai-guardian*",
+        "*sed*site-packages/ai_guardian*", "*sed*ai-guardian/src/ai_guardian*", "*sed*ai-guardian/ai_guardian*",
+        "*awk*ai-guardian*",
+        "*awk*site-packages/ai_guardian*", "*awk*ai-guardian/src/ai_guardian*", "*awk*ai-guardian/ai_guardian*",
         "*sed*.claude/settings.json*",
         "*sed*.cursor/hooks.json*",
         "*awk*.claude/settings.json*",
@@ -86,12 +90,14 @@ IMMUTABLE_DENY_PATTERNS = {
         "*nano*.claude/settings.json*",
         "*vim*.cursor/hooks.json*",
         "*nano*.cursor/hooks.json*",
-        "*chmod*ai-guardian*", "*chmod*ai_guardian*",
+        "*chmod*ai-guardian*",
+        "*chmod*site-packages/ai_guardian*", "*chmod*ai-guardian/src/ai_guardian*", "*chmod*ai-guardian/ai_guardian*",
         "*chmod*.claude/settings.json*",
         "*chmod*.cursor/hooks.json*",
         "*chattr*ai-guardian*",
         "*chattr*.claude*", "*chattr*.cursor*",
-        "*>*ai-guardian*", "*>*ai_guardian*",
+        "*>*ai-guardian*",
+        "*>*site-packages/ai_guardian*", "*>*ai-guardian/src/ai_guardian*", "*>*ai-guardian/ai_guardian*",
         "*>*.claude/settings.json*",
         "*>*.cursor/hooks.json*",
         "*rm*ai-guardian.json*",
@@ -116,13 +122,13 @@ IMMUTABLE_DENY_PATTERNS = {
 
     "PowerShell": [
         # Protect ai-guardian config files
-        "*Remove-Item*ai-guardian*", "*Remove-Item*ai_guardian*",
-        "*Move-Item*ai-guardian*", "*Move-Item*ai_guardian*",
-        "*Rename-Item*ai-guardian*", "*Rename-Item*ai_guardian*",
-        "*Set-Content*ai-guardian*", "*Set-Content*ai_guardian*",
-        "*Clear-Content*ai-guardian*", "*Clear-Content*ai_guardian*",
-        "*Out-File*ai-guardian*", "*Out-File*ai_guardian*",
-        "*Copy-Item*ai-guardian*", "*Copy-Item*ai_guardian*",
+        "*Remove-Item*ai-guardian*",
+        "*Move-Item*ai-guardian*",
+        "*Rename-Item*ai-guardian*",
+        "*Set-Content*ai-guardian*",
+        "*Clear-Content*ai-guardian*",
+        "*Out-File*ai-guardian*",
+        "*Copy-Item*ai-guardian*",
 
         # Protect IDE hook files (Unix paths)
         "*Remove-Item*.claude/settings.json*", "*Remove-Item*.cursor/hooks.json*",
@@ -147,10 +153,18 @@ IMMUTABLE_DENY_PATTERNS = {
         "*Out-File*Claude\\settings.json*", "*Out-File*Cursor\\hooks.json*",
 
         # Protect ai-guardian package source
-        "*Remove-Item*ai_guardian/*", "*Remove-Item*ai_guardian\\*",
-        "*Set-Content*ai_guardian/*", "*Set-Content*ai_guardian\\*",
-        "*Clear-Content*ai_guardian/*", "*Clear-Content*ai_guardian\\*",
-        "*Out-File*ai_guardian/*", "*Out-File*ai_guardian\\*",
+        "*Remove-Item*site-packages/ai_guardian/*", "*Remove-Item*site-packages\\ai_guardian\\*",
+        "*Remove-Item*ai-guardian/src/ai_guardian/*", "*Remove-Item*ai-guardian\\src\\ai_guardian\\*",
+        "*Remove-Item*ai-guardian/ai_guardian/*", "*Remove-Item*ai-guardian\\ai_guardian\\*",
+        "*Set-Content*site-packages/ai_guardian/*", "*Set-Content*site-packages\\ai_guardian\\*",
+        "*Set-Content*ai-guardian/src/ai_guardian/*", "*Set-Content*ai-guardian\\src\\ai_guardian\\*",
+        "*Set-Content*ai-guardian/ai_guardian/*", "*Set-Content*ai-guardian\\ai_guardian\\*",
+        "*Clear-Content*site-packages/ai_guardian/*", "*Clear-Content*site-packages\\ai_guardian\\*",
+        "*Clear-Content*ai-guardian/src/ai_guardian/*", "*Clear-Content*ai-guardian\\src\\ai_guardian\\*",
+        "*Clear-Content*ai-guardian/ai_guardian/*", "*Clear-Content*ai-guardian\\ai_guardian\\*",
+        "*Out-File*site-packages/ai_guardian/*", "*Out-File*site-packages\\ai_guardian\\*",
+        "*Out-File*ai-guardian/src/ai_guardian/*", "*Out-File*ai-guardian\\src\\ai_guardian\\*",
+        "*Out-File*ai-guardian/ai_guardian/*", "*Out-File*ai-guardian\\ai_guardian\\*",
 
         # Protect against PowerShell redirections
         "*>*ai-guardian*", "*>>*ai-guardian*",

--- a/tests/test_powershell_protection.py
+++ b/tests/test_powershell_protection.py
@@ -336,6 +336,76 @@ class PowerShellProtectionTest(TestCase):
         self.assertFalse(is_allowed, "PowerShell move alias on config should be blocked")
 
     # ========================================================================
+    # Test: Edge cases - User directories with 'ai_guardian' in path (Issue #47)
+    # ========================================================================
+
+    def test_powershell_allows_user_project_with_ai_guardian_in_name(self):
+        """PowerShell can modify user project with 'ai_guardian' in directory name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path C:\\Users\\user\\my_ai_guardian_project\\config.py -Value 'test'"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "PowerShell on user project with 'ai_guardian' should be allowed")
+        self.assertIsNone(error_msg)
+
+    def test_powershell_allows_remove_item_user_project(self):
+        """PowerShell Remove-Item allowed for user project with 'ai_guardian' in name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item /home/user/backup_ai_guardian_configs/old_file.txt"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "PowerShell Remove-Item on user directory with 'ai_guardian' should be allowed")
+
+    def test_powershell_still_blocks_site_packages(self):
+        """PowerShell cannot modify site-packages/ai_guardian/ (verify protection)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Set-Content -Path C:\\Python\\Lib\\site-packages\\ai_guardian\\tool_policy.py -Value ''"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Set-Content on site-packages/ai_guardian should still be blocked")
+        self.assertIn("CRITICAL FILE PROTECTED", error_msg)
+
+    def test_powershell_still_blocks_source_repo(self):
+        """PowerShell cannot modify ai-guardian/src/ai_guardian/ (verify protection)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "PowerShell",
+                "input": {
+                    "command": "Remove-Item /home/user/ai-guardian/src/ai_guardian/__init__.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "PowerShell Remove-Item on ai-guardian/src/ai_guardian should still be blocked")
+
+    # ========================================================================
     # Test: PowerShell cannot modify .ai-read-deny marker files
     # ========================================================================
 

--- a/tests/test_self_protection.py
+++ b/tests/test_self_protection.py
@@ -512,6 +512,144 @@ class SelfProtectionTest(TestCase):
         self.assertTrue(is_allowed, "Normal Bash commands should be allowed")
 
     # ========================================================================
+    # Test: Edge cases - User directories with 'ai_guardian' in path (Issue #47)
+    # ========================================================================
+
+    def test_write_allows_user_project_with_ai_guardian_in_name(self):
+        """AI can write to user project that has 'ai_guardian' in directory name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Write",
+                "input": {
+                    "file_path": "/home/user/my_ai_guardian_project/src/main.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "Write to user project with 'ai_guardian' in name should be allowed")
+        self.assertIsNone(error_msg, "No error message for allowed operation")
+
+    def test_write_allows_backup_directory_with_ai_guardian(self):
+        """AI can write to backup directory with 'ai_guardian' in name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Write",
+                "input": {
+                    "file_path": "/home/user/backup_ai_guardian_configs/settings.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "Write to backup directory with 'ai_guardian' should be allowed")
+        self.assertIsNone(error_msg)
+
+    def test_write_allows_tutorial_directory_with_ai_guardian(self):
+        """AI can write to tutorial directory with 'ai_guardian' in name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Write",
+                "input": {
+                    "file_path": "/home/user/projects/ai_guardian_tutorial/example.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "Write to tutorial directory with 'ai_guardian' should be allowed")
+
+    def test_write_still_blocks_site_packages(self):
+        """AI cannot write to site-packages/ai_guardian/ (verify protection still works)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Write",
+                "input": {
+                    "file_path": "/usr/lib/python3.12/site-packages/ai_guardian/tool_policy.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "Write to site-packages/ai_guardian should still be blocked")
+        self.assertIn("CRITICAL FILE PROTECTED", error_msg)
+
+    def test_write_still_blocks_source_repo(self):
+        """AI cannot write to ai-guardian/src/ai_guardian/ (verify protection still works)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Write",
+                "input": {
+                    "file_path": "/home/user/ai-guardian/src/ai_guardian/__init__.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "Write to ai-guardian/src/ai_guardian should still be blocked")
+        self.assertIn("CRITICAL FILE PROTECTED", error_msg)
+
+    def test_edit_allows_user_project_with_ai_guardian_in_name(self):
+        """AI can edit files in user project with 'ai_guardian' in directory name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Edit",
+                "input": {
+                    "file_path": "/home/user/my_ai_guardian_project/config.py",
+                    "old_string": "DEBUG = False",
+                    "new_string": "DEBUG = True"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "Edit of user project with 'ai_guardian' in name should be allowed")
+
+    def test_bash_allows_sed_on_user_project_with_ai_guardian(self):
+        """AI can use sed on user project with 'ai_guardian' in directory name"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": "sed -i 's/old/new/' /home/user/my_ai_guardian_project/config.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, "Bash sed on user project with 'ai_guardian' should be allowed")
+
+    def test_bash_still_blocks_sed_on_site_packages(self):
+        """AI cannot use sed on site-packages/ai_guardian/"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": "sed -i 's/IMMUTABLE/DISABLED/' /usr/lib/python3.12/site-packages/ai_guardian/tool_policy.py"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "Bash sed on site-packages/ai_guardian should still be blocked")
+
+    # ========================================================================
     # Test: AI cannot modify .ai-read-deny marker files (Write tool)
     # ========================================================================
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://redhat.atlassian.net/browse/itdove/ai-guardian#47>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR refines the `IMMUTABLE_DENY_PATTERNS` in the ai_guardian package to reduce false positives while maintaining protection against unauthorized modifications to the ai-guardian package itself. 

The changes improve the path pattern matching logic used for self-protection, making it more precise in identifying actual ai-guardian package files versus similarly-named files that should be allowed for modification. This addresses cases where legitimate file operations were incorrectly blocked due to overly broad pattern matching.

**Technical changes:**
- Updated path pattern definitions in `src/ai_guardian/tool_policy.py`
- Enhanced test coverage in `tests/test_self_protection.py` and `tests/test_powershell_protection.py` to verify the refined patterns

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_self_protection.py tests/test_powershell_protection.py -v`
3. Verify all tests pass, confirming that:
   - Self-protection patterns correctly block modifications to ai-guardian package files
   - Legitimate file operations on non-ai-guardian files are not blocked (false positives eliminated)
4. Optionally test in a live environment by attempting file operations on both ai-guardian package paths and similar but non-protected paths

### Scenarios tested
- Modified test cases for self-protection pattern matching
- Verified that ai-guardian package files remain protected from unauthorized modifications
- Confirmed that false positive scenarios (legitimate files being incorrectly blocked) are resolved
- Validated PowerShell protection integration remains functional

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: