### PR TITLE
itdove/ai-guardian#58: GitLab skill discovery hardcodes gitlab.com, breaks self-hosted GitLab instances

### DIFF
--- a/src/ai_guardian/skill_discovery.py
+++ b/src/ai_guardian/skill_discovery.py
@@ -100,13 +100,13 @@ class SkillDiscovery:
             logger.error(f"Invalid directory URL: {directory_url}")
             return set()
 
-        platform, owner, repo, branch, path = parsed
+        platform, hostname, owner, repo, branch, path = parsed
 
         # Discover skills from API
         if platform == "github":
-            skills = self._discover_github_skills(owner, repo, branch, path, token_env)
+            skills = self._discover_github_skills(hostname, owner, repo, branch, path, token_env)
         elif platform == "gitlab":
-            skills = self._discover_gitlab_skills(owner, repo, branch, path, token_env)
+            skills = self._discover_gitlab_skills(hostname, owner, repo, branch, path, token_env)
         else:
             logger.error(f"Unknown platform: {platform}")
             return set()
@@ -120,7 +120,7 @@ class SkillDiscovery:
 
         return skills
 
-    def _parse_directory_url(self, url: str) -> Optional[Tuple[str, str, str, str, str]]:
+    def _parse_directory_url(self, url: str) -> Optional[Tuple[str, str, str, str, str, str]]:
         """
         Parse GitHub/GitLab directory URL.
 
@@ -128,7 +128,7 @@ class SkillDiscovery:
             url: Directory URL
 
         Returns:
-            tuple or None: (platform, owner, repo, branch, path) or None if invalid
+            tuple or None: (platform, hostname, owner, repo, branch, path) or None if invalid
         """
         try:
             # GitHub: https://github.com/org/repo/tree/branch/path/to/dir
@@ -189,7 +189,7 @@ class SkillDiscovery:
                 branch = path_parts[tree_index + 2]
                 dir_path = '/'.join(path_parts[tree_index + 3:]) if len(path_parts) > tree_index + 3 else ""
 
-            return platform, owner, repo, branch, dir_path
+            return platform, hostname, owner, repo, branch, dir_path
 
         except Exception as e:
             logger.error(f"Error parsing directory URL {url}: {e}")
@@ -197,6 +197,7 @@ class SkillDiscovery:
 
     def _discover_github_skills(
         self,
+        hostname: str,
         owner: str,
         repo: str,
         branch: str,
@@ -207,6 +208,7 @@ class SkillDiscovery:
         Discover skills from GitHub directory.
 
         Args:
+            hostname: GitHub hostname (e.g., "github.com")
             owner: Repository owner
             repo: Repository name
             branch: Branch name
@@ -296,6 +298,7 @@ class SkillDiscovery:
 
     def _discover_gitlab_skills(
         self,
+        hostname: str,
         owner: str,
         repo: str,
         branch: str,
@@ -306,6 +309,7 @@ class SkillDiscovery:
         Discover skills from GitLab directory.
 
         Args:
+            hostname: GitLab hostname (e.g., "gitlab.com", "gitlab.example.com")
             owner: Repository owner/group
             repo: Repository name
             branch: Branch name
@@ -324,7 +328,7 @@ class SkillDiscovery:
 
             # GitLab API endpoint
             # https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
-            api_url = f"https://gitlab.com/api/v4/projects/{encoded_project}/repository/tree"
+            api_url = f"https://{hostname}/api/v4/projects/{encoded_project}/repository/tree"
 
             params = {
                 "ref": branch,
@@ -522,7 +526,7 @@ class SkillDiscovery:
         # Extract platform and owner for readable prefix
         parsed = self._parse_directory_url(directory_url)
         if parsed:
-            platform, owner, repo, _, _ = parsed
+            platform, hostname, owner, repo, _, _ = parsed
             prefix = f"{platform}_{owner}_{repo}".replace('/', '_').replace('.', '_')
         else:
             prefix = "unknown"

--- a/tests/test_skill_discovery.py
+++ b/tests/test_skill_discovery.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for skill_discovery module
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from ai_guardian.skill_discovery import SkillDiscovery
+
+
+class SkillDiscoveryTest(unittest.TestCase):
+    """Test suite for SkillDiscovery"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        # Create temporary cache directory
+        self.temp_dir = tempfile.mkdtemp()
+        self.cache_dir = Path(self.temp_dir) / "cache"
+        self.discovery = SkillDiscovery(cache_dir=self.cache_dir)
+
+    def tearDown(self):
+        """Clean up test fixtures"""
+        # Clean up temp directory
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_parse_github_url(self):
+        """Test parsing GitHub directory URL"""
+        url = "https://github.com/org/repo/tree/main/skills"
+        result = self.discovery._parse_directory_url(url)
+
+        self.assertIsNotNone(result)
+        platform, hostname, owner, repo, branch, path = result
+
+        self.assertEqual(platform, "github")
+        self.assertEqual(hostname, "github.com")
+        self.assertEqual(owner, "org")
+        self.assertEqual(repo, "repo")
+        self.assertEqual(branch, "main")
+        self.assertEqual(path, "skills")
+
+    def test_parse_gitlab_public_url(self):
+        """Test parsing public GitLab.com directory URL"""
+        url = "https://gitlab.com/org/repo/-/tree/main/skills"
+        result = self.discovery._parse_directory_url(url)
+
+        self.assertIsNotNone(result)
+        platform, hostname, owner, repo, branch, path = result
+
+        self.assertEqual(platform, "gitlab")
+        self.assertEqual(hostname, "gitlab.com")
+        self.assertEqual(owner, "org")
+        self.assertEqual(repo, "repo")
+        self.assertEqual(branch, "main")
+        self.assertEqual(path, "skills")
+
+    def test_parse_gitlab_selfhosted_url(self):
+        """Test parsing self-hosted GitLab directory URL"""
+        url = "https://gitlab.example.com/org/repo/-/tree/main/skills"
+        result = self.discovery._parse_directory_url(url)
+
+        self.assertIsNotNone(result)
+        platform, hostname, owner, repo, branch, path = result
+
+        self.assertEqual(platform, "gitlab")
+        self.assertEqual(hostname, "gitlab.example.com")
+        self.assertEqual(owner, "org")
+        self.assertEqual(repo, "repo")
+        self.assertEqual(branch, "main")
+        self.assertEqual(path, "skills")
+
+    def test_parse_gitlab_multilevel_group_url(self):
+        """Test parsing GitLab URL with multi-level groups"""
+        url = "https://gitlab.example.com/group/subgroup/repo/-/tree/develop/path/to/skills"
+        result = self.discovery._parse_directory_url(url)
+
+        self.assertIsNotNone(result)
+        platform, hostname, owner, repo, branch, path = result
+
+        self.assertEqual(platform, "gitlab")
+        self.assertEqual(hostname, "gitlab.example.com")
+        self.assertEqual(owner, "group/subgroup")
+        self.assertEqual(repo, "repo")
+        self.assertEqual(branch, "develop")
+        self.assertEqual(path, "path/to/skills")
+
+    def test_discover_gitlab_public_skills(self):
+        """Test discovering skills from public GitLab.com"""
+        url = "https://gitlab.com/org/repo/-/tree/main/skills"
+
+        # Mock GitLab API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"name": "arc", "type": "tree"},
+            {"name": "code-review", "type": "tree"},
+            {"name": ".hidden", "type": "tree"},  # Should be skipped
+            {"name": "README.md", "type": "blob"},  # Should be skipped
+        ]
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
+
+            # Verify API was called with correct URL
+            self.assertTrue(mock_get.called)
+            call_args = mock_get.call_args
+            api_url = call_args[0][0]
+
+            # Should use gitlab.com, not hardcoded
+            self.assertIn("https://gitlab.com/api/v4", api_url)
+            self.assertIn("org%2Frepo", api_url)
+
+            # Verify skills were discovered
+            self.assertEqual(skills, {"Skill:arc", "Skill:code-review"})
+
+    def test_discover_gitlab_selfhosted_skills(self):
+        """Test discovering skills from self-hosted GitLab instance"""
+        url = "https://gitlab.example.com/org/repo/-/tree/main/skills"
+
+        # Mock GitLab API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"name": "daf-active", "type": "tree"},
+            {"name": "daf-config", "type": "tree"},
+        ]
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
+
+            # Verify API was called with self-hosted hostname
+            self.assertTrue(mock_get.called)
+            call_args = mock_get.call_args
+            api_url = call_args[0][0]
+
+            # CRITICAL: Should use gitlab.example.com, NOT gitlab.com
+            self.assertIn("https://gitlab.example.com/api/v4", api_url)
+            self.assertNotIn("gitlab.com/api/v4", api_url)
+
+            # Verify skills were discovered
+            self.assertEqual(skills, {"Skill:daf-active", "Skill:daf-config"})
+
+    def test_discover_github_skills(self):
+        """Test discovering skills from GitHub"""
+        url = "https://github.com/org/repo/tree/main/skills"
+
+        # Mock GitHub API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"name": "release", "type": "dir"},
+            {"name": "init", "type": "dir"},
+            {"name": "__pycache__", "type": "dir"},  # Should be skipped
+            {"name": "README.md", "type": "file"},  # Should be skipped
+        ]
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
+
+            # Verify API was called with correct URL
+            self.assertTrue(mock_get.called)
+            call_args = mock_get.call_args
+            api_url = call_args[0][0]
+
+            # Should use GitHub API
+            self.assertIn("https://api.github.com/repos/org/repo/contents", api_url)
+
+            # Verify skills were discovered
+            self.assertEqual(skills, {"Skill:release", "Skill:init"})
+
+    def test_gitlab_authentication_token(self):
+        """Test GitLab authentication with custom token"""
+        url = "https://gitlab.example.com/org/repo/-/tree/main/skills"
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [{"name": "test-skill", "type": "tree"}]
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            with patch('os.environ.get', return_value="custom-token"):
+                skills = self.discovery.discover_skills(
+                    url,
+                    cache_ttl_hours=0,
+                    token_env="CUSTOM_GITLAB_TOKEN"
+                )
+
+                # Verify authentication header was set
+                self.assertTrue(mock_get.called)
+                call_kwargs = mock_get.call_args[1]
+                headers = call_kwargs.get('headers', {})
+
+                self.assertIn('PRIVATE-TOKEN', headers)
+                self.assertEqual(headers['PRIVATE-TOKEN'], 'custom-token')
+
+    def test_gitlab_404_error(self):
+        """Test handling of 404 error from GitLab API"""
+        url = "https://gitlab.example.com/org/repo/-/tree/main/nonexistent"
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+
+        with patch('requests.get', return_value=mock_response):
+            skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
+
+            # Should return empty set on 404
+            self.assertEqual(skills, set())
+
+    def test_gitlab_401_unauthorized(self):
+        """Test handling of 401 authentication error"""
+        url = "https://gitlab.example.com/org/private-repo/-/tree/main/skills"
+
+        mock_response = Mock()
+        mock_response.status_code = 401
+
+        with patch('requests.get', return_value=mock_response):
+            skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
+
+            # Should return empty set on 401
+            self.assertEqual(skills, set())
+
+    def test_local_directory_discovery(self):
+        """Test discovering skills from local filesystem"""
+        # Create temporary skill directories
+        skills_dir = Path(self.temp_dir) / "local-skills"
+        skills_dir.mkdir()
+
+        (skills_dir / "skill-a").mkdir()
+        (skills_dir / "skill-b").mkdir()
+        (skills_dir / ".hidden").mkdir()  # Should be skipped
+        (skills_dir / "__pycache__").mkdir()  # Should be skipped
+
+        # Discover from local path
+        skills = self.discovery.discover_skills(str(skills_dir))
+
+        # Verify skills were discovered
+        self.assertEqual(skills, {"Skill:skill-a", "Skill:skill-b"})
+
+    def test_cache_functionality(self):
+        """Test that skill discovery results are cached"""
+        url = "https://gitlab.example.com/org/repo/-/tree/main/skills"
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"name": "cached-skill", "type": "tree"}
+        ]
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            # First call - should hit API
+            skills1 = self.discovery.discover_skills(url, cache_ttl_hours=24)
+            first_call_count = mock_get.call_count
+
+            # Second call - should use cache
+            skills2 = self.discovery.discover_skills(url, cache_ttl_hours=24)
+            second_call_count = mock_get.call_count
+
+            # Verify cache was used (no additional API call)
+            self.assertEqual(first_call_count, second_call_count)
+            self.assertEqual(skills1, skills2)
+            self.assertEqual(skills1, {"Skill:cached-skill"})
+
+    def test_invalid_url_format(self):
+        """Test handling of invalid URL formats"""
+        invalid_urls = [
+            "https://example.com/not-a-repo",
+            "https://github.com/org",  # Missing parts
+            "https://gitlab.com/org/repo/tree/main",  # Missing -/ for GitLab
+            "not-a-url-at-all",
+        ]
+
+        for invalid_url in invalid_urls:
+            result = self.discovery._parse_directory_url(invalid_url)
+            # Most should return None (invalid format)
+            # The last one is not http/https so it will be treated as local path
+            if invalid_url.startswith("http"):
+                self.assertIsNone(result, f"Expected None for {invalid_url}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--- This PR addresses a GitHub issue rather than a Jira item -->
GitHub Issue: itdove/ai-guardian#58
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes a bug where GitLab skill discovery hardcoded `gitlab.com` as the hostname, preventing the system from working with self-hosted GitLab instances.

**Changes:**
- Refactored skill discovery logic to dynamically extract and use the hostname from skill directory URLs instead of hardcoding `gitlab.com`
- Updated `src/ai_guardian/skill_discovery.py` to parse the hostname from the skill repository URL
- Added test coverage in `tests/test_skill_discovery.py` to verify correct hostname extraction for both gitlab.com and self-hosted GitLab instances

This allows the AI Guardian skill discovery system to work seamlessly with any GitLab instance (cloud or self-hosted) by respecting the actual hostname in the skill directory configuration.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Configure a skill directory pointing to a self-hosted GitLab instance (e.g., `https://gitlab.example.com/org/skills`)
3. Run the skill discovery process
4. Verify that skills are correctly discovered and the URLs use the correct hostname (`gitlab.example.com` instead of `gitlab.com`)
5. Test with a gitlab.com-hosted skill directory to ensure backward compatibility
6. Run the test suite: `pytest tests/test_skill_discovery.py`

### Scenarios tested
- Skill discovery with self-hosted GitLab instance URLs
- Skill discovery with standard gitlab.com URLs (backward compatibility)
- Hostname extraction from various URL formats
- Unit tests covering hostname parsing edge cases

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: