### PR TITLE
itdove/ai-guardian#71: Schema does not match code implementation for permissions_directories

### DIFF
--- a/src/ai_guardian/schemas/ai-guardian-config.schema.json
+++ b/src/ai_guardian/schemas/ai-guardian-config.schema.json
@@ -14,24 +14,36 @@
       }
     },
     "permissions_directories": {
-      "type": "object",
-      "description": "OPTIONAL/ADVANCED: Auto-discover permissions from directories. Most users should use remote_configs instead.",
-      "properties": {
-        "deny": {
-          "type": "array",
-          "description": "Directories to scan for deny patterns",
-          "items": {
-            "$ref": "#/definitions/directory_entry"
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Object format with allow/deny arrays (backward compatible)",
+          "properties": {
+            "deny": {
+              "type": "array",
+              "description": "Directories to scan for deny patterns",
+              "items": {
+                "$ref": "#/definitions/directory_entry"
+              }
+            },
+            "allow": {
+              "type": "array",
+              "description": "Directories to scan for allow patterns",
+              "items": {
+                "$ref": "#/definitions/directory_entry"
+              }
+            }
           }
         },
-        "allow": {
+        {
           "type": "array",
-          "description": "Directories to scan for allow patterns",
+          "description": "Array format with mode in each entry (NEW: mode field actually used)",
           "items": {
             "$ref": "#/definitions/directory_entry"
           }
         }
-      }
+      ],
+      "description": "OPTIONAL/ADVANCED: Auto-discover permissions from directories. Most users should use remote_configs instead. Supports both object format (allow/deny arrays) and direct array format."
     },
     "remote_configs": {
       "type": "object",
@@ -362,17 +374,19 @@
     },
     "directory_entry": {
       "type": "object",
-      "required": ["matcher", "mode", "url"],
-      "description": "Directory to scan for auto-discovery of permissions",
+      "required": ["url"],
+      "description": "Directory to scan for auto-discovery of permissions. In object format (allow/deny arrays), mode is determined by which array the entry is in. In array format, mode defaults to 'allow' if not specified.",
       "properties": {
         "matcher": {
           "type": "string",
-          "description": "Tool type to apply discovered patterns to (e.g., 'Skill', 'mcp__*')"
+          "description": "Tool type to apply discovered patterns to (e.g., 'Skill', 'mcp__*'). Defaults to 'Skill' if not specified.",
+          "default": "Skill"
         },
         "mode": {
           "type": "string",
           "enum": ["allow", "deny"],
-          "description": "Permission mode for discovered patterns"
+          "description": "Permission mode for discovered patterns. Only used in array format; ignored in object format (allow/deny arrays). Defaults to 'allow'.",
+          "default": "allow"
         },
         "url": {
           "type": "string",

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -1697,7 +1697,7 @@ class ToolPolicyChecker:
             for dir_entry in allow_dirs:
                 discovered_items = self._discover_directory_items(discovery, dir_entry, cache_ttl)
                 if discovered_items:
-                    matcher = dir_entry.get("category", "Skill")
+                    matcher = dir_entry.get("matcher", "Skill")
                     self._add_to_permission_rule(config, matcher, "allow", discovered_items)
 
             # Process deny directories
@@ -1705,7 +1705,7 @@ class ToolPolicyChecker:
             for dir_entry in deny_dirs:
                 discovered_items = self._discover_directory_items(discovery, dir_entry, cache_ttl)
                 if discovered_items:
-                    matcher = dir_entry.get("category", "Skill")
+                    matcher = dir_entry.get("matcher", "Skill")
                     self._add_to_permission_rule(config, matcher, "deny", discovered_items)
 
         except ImportError:
@@ -1719,11 +1719,11 @@ class ToolPolicyChecker:
 
         Args:
             discovery: SkillDiscovery instance
-            dir_entry: Directory entry dict with url, category, token_env
+            dir_entry: Directory entry dict with url, matcher, token_env
             cache_ttl: Cache TTL in hours
 
         Returns:
-            list: List of item names (without category prefix)
+            list: List of item names (without matcher prefix)
         """
         try:
             url = dir_entry.get("url")


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->
Related GitHub Issue: <https://github.com/itdove/ai-guardian/issues/71>

## Description
This PR fixes a schema mismatch where the field name in the permissions directory processing did not match the code implementation. The schema defined `permissions_directories` but the code was using a different field name, causing validation errors or incorrect configuration parsing.

Changes made:
- Updated `ai-guardian-config.schema.json` to align field naming with code implementation
- Corrected field reference in `tool_policy.py` to match schema definition

This ensures consistency between the JSON schema validation and the actual code that processes permissions directory configuration.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Create or use an existing ai-guardian configuration file that includes permissions directory settings
3. Validate the configuration against the updated schema using a JSON schema validator
4. Run the ai-guardian tool with the configuration to verify permissions_directories are processed correctly
5. Verify no validation errors occur and permissions are applied as expected

### Scenarios tested
- Configuration file with permissions_directories field validates successfully against schema
- Tool policy correctly reads and processes permissions_directories from configuration
- No schema validation errors when using the corrected field name

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: