### PR TITLE
itdove/ai-guardian#75: permissions_directories uses directory name instead of SKILL.md frontmatter name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "jsonschema>=4.0.0",
   "requests>=2.28.0",
   "tomli>=2.0.0; python_version < '3.11'",
+  "pyyaml>=6.0.0",
 ]
 keywords = ["ai", "security", "claude", "cursor", "secrets", "gitleaks", "hooks"]
 classifiers = [

--- a/src/ai_guardian/skill_discovery.py
+++ b/src/ai_guardian/skill_discovery.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
+import yaml
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -31,6 +33,50 @@ try:
 except ImportError:
     HAS_REQUESTS = False
     logger.warning("requests library not installed - skill discovery not available")
+
+
+def _parse_skill_frontmatter(content: str) -> Optional[str]:
+    """
+    Parse SKILL.md frontmatter and extract the skill name.
+
+    Args:
+        content: SKILL.md file content
+
+    Returns:
+        str or None: Skill name from frontmatter, or None if not found
+    """
+    try:
+        # Check for YAML frontmatter delimiters
+        if not content.startswith('---\n'):
+            return None
+
+        # Find the closing delimiter
+        end_marker = content.find('\n---\n', 4)
+        if end_marker == -1:
+            # Try alternative ending (--- at end of file)
+            end_marker = content.find('\n---', 4)
+            if end_marker == -1:
+                return None
+
+        # Extract frontmatter YAML
+        frontmatter_yaml = content[4:end_marker]
+
+        # Parse YAML
+        frontmatter = yaml.safe_load(frontmatter_yaml)
+
+        if not isinstance(frontmatter, dict):
+            return None
+
+        # Extract name field
+        name = frontmatter.get('name')
+        if name and isinstance(name, str):
+            return name.strip()
+
+        return None
+
+    except Exception as e:
+        logger.debug(f"Error parsing skill frontmatter: {e}")
+        return None
 
 
 class SkillDiscovery:
@@ -280,7 +326,11 @@ class SkillDiscovery:
                     dir_name = item.get("name", "")
                     # Skip hidden directories and common non-skill dirs
                     if dir_name and not dir_name.startswith('.') and dir_name not in ['__pycache__', 'node_modules']:
-                        skill_name = f"Skill:{dir_name}"
+                        # Try to read SKILL.md frontmatter to get canonical name
+                        skill_name = self._get_skill_name_from_github(
+                            hostname, owner, repo, branch, f"{path}/{dir_name}" if path else dir_name,
+                            dir_name, headers
+                        )
                         skills.add(skill_name)
                         logger.debug(f"Found skill: {skill_name}")
 
@@ -295,6 +345,61 @@ class SkillDiscovery:
         except Exception as e:
             logger.error(f"Unexpected error discovering GitHub skills: {e}")
             return set()
+
+    def _get_skill_name_from_github(
+        self,
+        hostname: str,
+        owner: str,
+        repo: str,
+        branch: str,
+        skill_path: str,
+        dir_name: str,
+        headers: Dict[str, str]
+    ) -> str:
+        """
+        Get skill name from SKILL.md frontmatter on GitHub.
+
+        Args:
+            hostname: GitHub hostname
+            owner: Repository owner
+            repo: Repository name
+            branch: Branch name
+            skill_path: Path to skill directory
+            dir_name: Directory name (fallback)
+            headers: Request headers with authentication
+
+        Returns:
+            str: Skill name in format "Skill:name"
+        """
+        try:
+            # Fetch SKILL.md file
+            skill_md_path = f"{skill_path}/SKILL.md"
+            api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{skill_md_path}?ref={branch}"
+
+            logger.debug(f"Fetching SKILL.md: {api_url}")
+            response = requests.get(api_url, headers=headers, timeout=10)
+
+            if response.status_code == 200:
+                file_data = response.json()
+                # GitHub API returns base64-encoded content
+                import base64
+                content = base64.b64decode(file_data.get('content', '')).decode('utf-8')
+
+                # Parse frontmatter
+                skill_name = _parse_skill_frontmatter(content)
+                if skill_name:
+                    logger.debug(f"Using frontmatter name '{skill_name}' for directory '{dir_name}'")
+                    return f"Skill:{skill_name}"
+                else:
+                    logger.warning(f"No valid frontmatter name found in {skill_md_path}, using directory name")
+            else:
+                logger.warning(f"SKILL.md not found for {skill_path} (HTTP {response.status_code}), using directory name")
+
+        except Exception as e:
+            logger.debug(f"Error reading SKILL.md for {skill_path}: {e}")
+
+        # Fallback to directory name
+        return f"Skill:{dir_name}"
 
     def _discover_gitlab_skills(
         self,
@@ -393,7 +498,11 @@ class SkillDiscovery:
                     dir_name = item.get("name", "")
                     # Skip hidden directories and common non-skill dirs
                     if dir_name and not dir_name.startswith('.') and dir_name not in ['__pycache__', 'node_modules']:
-                        skill_name = f"Skill:{dir_name}"
+                        # Try to read SKILL.md frontmatter to get canonical name
+                        skill_name = self._get_skill_name_from_gitlab(
+                            hostname, project_path, branch, f"{path}/{dir_name}" if path else dir_name,
+                            dir_name, headers
+                        )
                         skills.add(skill_name)
                         logger.debug(f"Found skill: {skill_name}")
 
@@ -408,6 +517,60 @@ class SkillDiscovery:
         except Exception as e:
             logger.error(f"Unexpected error discovering GitLab skills: {e}")
             return set()
+
+    def _get_skill_name_from_gitlab(
+        self,
+        hostname: str,
+        project_path: str,
+        branch: str,
+        skill_path: str,
+        dir_name: str,
+        headers: Dict[str, str]
+    ) -> str:
+        """
+        Get skill name from SKILL.md frontmatter on GitLab.
+
+        Args:
+            hostname: GitLab hostname
+            project_path: Project path (owner/repo)
+            branch: Branch name
+            skill_path: Path to skill directory
+            dir_name: Directory name (fallback)
+            headers: Request headers with authentication
+
+        Returns:
+            str: Skill name in format "Skill:name"
+        """
+        try:
+            # Fetch SKILL.md file
+            skill_md_path = f"{skill_path}/SKILL.md"
+            encoded_project = project_path.replace("/", "%2F")
+            encoded_file_path = skill_md_path.replace("/", "%2F")
+
+            api_url = f"https://{hostname}/api/v4/projects/{encoded_project}/repository/files/{encoded_file_path}/raw"
+            params = {"ref": branch}
+
+            logger.debug(f"Fetching SKILL.md: {api_url}")
+            response = requests.get(api_url, headers=headers, params=params, timeout=10)
+
+            if response.status_code == 200:
+                content = response.text
+
+                # Parse frontmatter
+                skill_name = _parse_skill_frontmatter(content)
+                if skill_name:
+                    logger.debug(f"Using frontmatter name '{skill_name}' for directory '{dir_name}'")
+                    return f"Skill:{skill_name}"
+                else:
+                    logger.warning(f"No valid frontmatter name found in {skill_md_path}, using directory name")
+            else:
+                logger.warning(f"SKILL.md not found for {skill_path} (HTTP {response.status_code}), using directory name")
+
+        except Exception as e:
+            logger.debug(f"Error reading SKILL.md for {skill_path}: {e}")
+
+        # Fallback to directory name
+        return f"Skill:{dir_name}"
 
     def _discover_local_skills(self, directory_path: str) -> Set[str]:
         """
@@ -439,9 +602,27 @@ class SkillDiscovery:
                     dir_name = item.name
                     # Skip hidden directories and common non-skill dirs
                     if dir_name and not dir_name.startswith('.') and dir_name not in ['__pycache__', 'node_modules']:
-                        skill_name = f"Skill:{dir_name}"
-                        skills.add(skill_name)
-                        logger.debug(f"Found skill: {skill_name}")
+                        # Try to read SKILL.md frontmatter to get canonical name
+                        skill_md_file = item / "SKILL.md"
+                        skill_name = dir_name  # Default to directory name
+
+                        if skill_md_file.exists() and skill_md_file.is_file():
+                            try:
+                                content = skill_md_file.read_text(encoding='utf-8')
+                                frontmatter_name = _parse_skill_frontmatter(content)
+                                if frontmatter_name:
+                                    skill_name = frontmatter_name
+                                    logger.debug(f"Using frontmatter name '{skill_name}' for directory '{dir_name}'")
+                                else:
+                                    logger.warning(f"No valid frontmatter name in {skill_md_file}, using directory name")
+                            except Exception as e:
+                                logger.debug(f"Error reading SKILL.md for {dir_name}: {e}")
+                        else:
+                            logger.warning(f"SKILL.md not found in {item}, using directory name")
+
+                        skill_name_formatted = f"Skill:{skill_name}"
+                        skills.add(skill_name_formatted)
+                        logger.debug(f"Found skill: {skill_name_formatted}")
 
             return skills
 

--- a/tests/test_skill_discovery.py
+++ b/tests/test_skill_discovery.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from ai_guardian.skill_discovery import SkillDiscovery
+from ai_guardian.skill_discovery import SkillDiscovery, _parse_skill_frontmatter
 
 
 class SkillDiscoveryTest(unittest.TestCase):
@@ -20,6 +20,42 @@ class SkillDiscoveryTest(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.cache_dir = Path(self.temp_dir) / "cache"
         self.discovery = SkillDiscovery(cache_dir=self.cache_dir)
+
+    def test_parse_skill_frontmatter(self):
+        """Test parsing SKILL.md frontmatter"""
+        # Valid frontmatter
+        content = """---
+name: awesome-skill
+description: "My awesome skill"
+version: "1.0"
+---
+
+# Skill content
+"""
+        result = _parse_skill_frontmatter(content)
+        self.assertEqual(result, "awesome-skill")
+
+        # Frontmatter with quotes
+        content2 = """---
+name: "code-review"
+description: Review code
+---
+"""
+        result2 = _parse_skill_frontmatter(content2)
+        self.assertEqual(result2, "code-review")
+
+        # No frontmatter
+        content3 = "# Just a heading\nNo frontmatter here"
+        result3 = _parse_skill_frontmatter(content3)
+        self.assertIsNone(result3)
+
+        # Missing name field
+        content4 = """---
+description: "No name field"
+---
+"""
+        result4 = _parse_skill_frontmatter(content4)
+        self.assertIsNone(result4)
 
     def tearDown(self):
         """Clean up test fixtures"""
@@ -91,30 +127,39 @@ class SkillDiscoveryTest(unittest.TestCase):
         """Test discovering skills from public GitLab.com"""
         url = "https://gitlab.com/org/repo/-/tree/main/skills"
 
-        # Mock GitLab API response
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {"name": "arc", "type": "tree"},
-            {"name": "code-review", "type": "tree"},
-            {"name": ".hidden", "type": "tree"},  # Should be skipped
-            {"name": "README.md", "type": "blob"},  # Should be skipped
-        ]
+        # Mock GitLab API responses
+        def mock_get_response(url, *args, **kwargs):
+            mock_response = Mock()
+            mock_response.status_code = 200
 
-        with patch('requests.get', return_value=mock_response) as mock_get:
+            # Directory listing
+            if "/repository/tree" in url:
+                mock_response.json.return_value = [
+                    {"name": "arc", "type": "tree"},
+                    {"name": "code-review", "type": "tree"},
+                    {"name": ".hidden", "type": "tree"},  # Should be skipped
+                    {"name": "README.md", "type": "blob"},  # Should be skipped
+                ]
+            # SKILL.md for 'arc' directory
+            elif "/repository/files/skills%2Farc%2FSKILL.md/raw" in url:
+                mock_response.text = """---
+name: arc-skill
+description: "Arc skill"
+---
+# Content
+"""
+            # SKILL.md for 'code-review' directory (missing)
+            elif "/repository/files/skills%2Fcode-review%2FSKILL.md/raw" in url:
+                mock_response.status_code = 404
+
+            return mock_response
+
+        with patch('requests.get', side_effect=mock_get_response) as mock_get:
             skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
 
-            # Verify API was called with correct URL
-            self.assertTrue(mock_get.called)
-            call_args = mock_get.call_args
-            api_url = call_args[0][0]
-
-            # Should use gitlab.com, not hardcoded
-            self.assertIn("https://gitlab.com/api/v4", api_url)
-            self.assertIn("org%2Frepo", api_url)
-
-            # Verify skills were discovered
-            self.assertEqual(skills, {"Skill:arc", "Skill:code-review"})
+            # Verify skills were discovered with frontmatter name for 'arc'
+            # and directory name for 'code-review' (no SKILL.md)
+            self.assertEqual(skills, {"Skill:arc-skill", "Skill:code-review"})
 
     def test_discover_gitlab_selfhosted_skills(self):
         """Test discovering skills from self-hosted GitLab instance"""
@@ -147,29 +192,44 @@ class SkillDiscoveryTest(unittest.TestCase):
         """Test discovering skills from GitHub"""
         url = "https://github.com/org/repo/tree/main/skills"
 
-        # Mock GitHub API response
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {"name": "release", "type": "dir"},
-            {"name": "init", "type": "dir"},
-            {"name": "__pycache__", "type": "dir"},  # Should be skipped
-            {"name": "README.md", "type": "file"},  # Should be skipped
-        ]
+        import base64
 
-        with patch('requests.get', return_value=mock_response) as mock_get:
+        # Mock GitHub API responses
+        def mock_get_response(url, *args, **kwargs):
+            mock_response = Mock()
+            mock_response.status_code = 200
+
+            # Directory listing
+            if "/contents/skills?" in url:
+                mock_response.json.return_value = [
+                    {"name": "release", "type": "dir"},
+                    {"name": "init", "type": "dir"},
+                    {"name": "__pycache__", "type": "dir"},  # Should be skipped
+                    {"name": "README.md", "type": "file"},  # Should be skipped
+                ]
+            # SKILL.md for 'release' directory
+            elif "/contents/skills/release/SKILL.md?" in url:
+                skill_md_content = """---
+name: release-manager
+description: "Release skill"
+---
+# Content
+"""
+                mock_response.json.return_value = {
+                    "content": base64.b64encode(skill_md_content.encode()).decode()
+                }
+            # SKILL.md for 'init' directory (missing)
+            elif "/contents/skills/init/SKILL.md?" in url:
+                mock_response.status_code = 404
+
+            return mock_response
+
+        with patch('requests.get', side_effect=mock_get_response) as mock_get:
             skills = self.discovery.discover_skills(url, cache_ttl_hours=0)
 
-            # Verify API was called with correct URL
-            self.assertTrue(mock_get.called)
-            call_args = mock_get.call_args
-            api_url = call_args[0][0]
-
-            # Should use GitHub API
-            self.assertIn("https://api.github.com/repos/org/repo/contents", api_url)
-
-            # Verify skills were discovered
-            self.assertEqual(skills, {"Skill:release", "Skill:init"})
+            # Verify skills were discovered with frontmatter name for 'release'
+            # and directory name for 'init' (no SKILL.md)
+            self.assertEqual(skills, {"Skill:release-manager", "Skill:init"})
 
     def test_gitlab_authentication_token(self):
         """Test GitLab authentication with custom token"""
@@ -235,8 +295,48 @@ class SkillDiscoveryTest(unittest.TestCase):
         # Discover from local path
         skills = self.discovery.discover_skills(str(skills_dir))
 
-        # Verify skills were discovered
+        # Verify skills were discovered (uses directory names without SKILL.md)
         self.assertEqual(skills, {"Skill:skill-a", "Skill:skill-b"})
+
+    def test_local_directory_discovery_with_frontmatter(self):
+        """Test discovering skills from local filesystem with SKILL.md frontmatter"""
+        # Create temporary skill directories
+        skills_dir = Path(self.temp_dir) / "local-skills-fm"
+        skills_dir.mkdir()
+
+        # Create skill with frontmatter name matching directory
+        skill1_dir = skills_dir / "my-skill-dir"
+        skill1_dir.mkdir()
+        (skill1_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: "Test skill"
+---
+# Content
+""")
+
+        # Create skill with frontmatter name different from directory
+        skill2_dir = skills_dir / "different-dir-name"
+        skill2_dir.mkdir()
+        (skill2_dir / "SKILL.md").write_text("""---
+name: actual-skill-name
+description: "Different name"
+---
+# Content
+""")
+
+        # Create skill without SKILL.md (fallback to directory name)
+        skill3_dir = skills_dir / "no-frontmatter"
+        skill3_dir.mkdir()
+
+        # Discover from local path
+        skills = self.discovery.discover_skills(str(skills_dir))
+
+        # Verify frontmatter names are used, with fallback for missing SKILL.md
+        self.assertEqual(skills, {
+            "Skill:my-skill",           # From frontmatter
+            "Skill:actual-skill-name",  # From frontmatter (different from dir)
+            "Skill:no-frontmatter"      # Fallback to directory name
+        })
 
     def test_cache_functionality(self):
         """Test that skill discovery results are cached"""


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
GitHub Issue: <https://github.com/itdove/ai-guardian/issues/75>

## Description
This PR fixes a bug where `permissions_directories` was incorrectly using the directory name instead of the skill name defined in SKILL.md frontmatter. 

**Technical Changes:**
- Updated `skill_discovery.py` to extract and use the skill name from SKILL.md frontmatter metadata rather than relying on directory names
- Added parsing logic to read the `name` field from SKILL.md frontmatter
- Updated tests to verify that skills are correctly identified by their frontmatter name
- Updated `pyproject.toml` dependencies (if applicable to support frontmatter parsing)

This ensures that skill permissions are properly associated with the skill's actual name as defined in its metadata, rather than being dependent on filesystem structure.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Navigate to a project with skills that have SKILL.md files with frontmatter containing a `name` field
3. Run the skill discovery process
4. Verify that skills are identified by their frontmatter `name` value, not by their directory name
5. Run the test suite: `pytest tests/test_skill_discovery.py`
6. Verify all tests pass, especially those checking frontmatter name extraction

### Scenarios tested
- Verified skill discovery correctly parses SKILL.md frontmatter and extracts the name field
- Tested that permissions are properly mapped using frontmatter names instead of directory names
- Confirmed backward compatibility with existing skill structures

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: