### PR TITLE
itdove/ai-guardian#84: Add ignore_files support to prompt injection detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Skip detection for specific files using glob patterns
   - Supports glob wildcards: `*` (any chars except /), `**` (any chars including /), `?` (single char)
   - Supports tilde expansion: `~` expands to home directory
-  - Examples: `"**/.claude/skills/*/SKILL.md"`, `"**/tests/fixtures/**"`, `"**/.env.example"`
-  - Use cases: SKILL.md files, test fixtures with fake credentials, example configuration files
+  - Examples: `"**/.claude/skills/*/SKILL.md"`, `"**/.claude/projects/**/tool-results/**"`, `"**/tests/fixtures/**"`, `"**/.env.example"`
+  - Use cases: SKILL.md files, cached tool results, test fixtures with fake credentials, example configuration files
+  - Recommended pattern for skills: `"**/.claude/projects/**/tool-results/**"` prevents re-scanning cached skill outputs
   - Available in both `prompt_injection` and `secret_scanning` configuration sections
 - **Defense in depth**: Use both `ignore_tools` and `ignore_files` together for comprehensive false positive handling
 - Comprehensive test coverage: 10 new tests for `ignore_tools`, 9 new tests for `ignore_files`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Skip detection for specific tools using patterns: `"Skill:code-review"`, `"Skill:*"`, `"mcp__*"`
   - Granular control: ignore specific skills (e.g., `"Skill:code-review"`) or all skills (`"Skill"` or `"Skill:*"`)
   - Composite tool identifiers: automatically created for Skill tools (e.g., `"Skill:code-review"`)
+  - **PreToolUse + PostToolUse correlation**: ignore_tools patterns now work on BOTH:
+    - PreToolUse: tool inputs (e.g., Skill reading SKILL.md documentation)
+    - PostToolUse: tool outputs (e.g., Skill execution results)
+    - Correlation ensures cached tool results inherit ignore from original invocation
   - Supports wildcards: `*` (any chars), `?` (single char)
   - Use case: Skill documentation with example attack patterns no longer triggers false positives
   - Available in both `prompt_injection` and `secret_scanning` configuration sections
@@ -27,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example configuration files: `examples/ignore-tools-config.json`, `examples/secret-scanning-ignore-config.json`
 
 ### Changed
+- **Improved logging for debugging false positives**
+  - Log messages now include full file paths (not just filenames)
+  - Before: `"Scanning file 'SKILL.md' for secrets..."`
+  - After: `"Scanning file 'SKILL.md' (/home/user/.claude/skills/foo/SKILL.md) for secrets..."`
+  - Prompt injection warnings now include file path: `"Prompt injection detected in /path/to/file, blocking operation"`
+  - Makes it easy to identify which specific file triggered detection
+  - Helps users quickly add files to `ignore_files` configuration
 
 ### Fixed
 - **CRITICAL: Bash tool bypass vulnerability** (discovered during code review)

--- a/README.md
+++ b/README.md
@@ -1191,10 +1191,19 @@ If legitimate prompts are being blocked, you have several options:
 ```
 
 **Tool patterns:**
-- `"Skill:code-review"` - Ignore only the code-review skill
+- `"Skill:code-review"` - Ignore only the code-review skill (both input and output)
 - `"Skill:*"` or `"Skill"` - Ignore all skills
 - `"mcp__notebooklm__*"` - Ignore all NotebookLM MCP tools
 - `"Read"` - Ignore the Read tool
+
+**How ignore_tools works (NEW in v1.4.0):**
+- **PreToolUse**: Scans tool inputs (e.g., file content before tool reads it)
+- **PostToolUse**: Scans tool outputs (e.g., skill execution results)
+- **Correlation**: Skill tools automatically correlate input and output
+  - Example: `"Skill:code-review"` ignores:
+    - ✅ Reading code-review SKILL.md documentation (PreToolUse)
+    - ✅ Code-review skill execution results (PostToolUse)
+  - Prevents false positives from educational attack patterns in skill docs
 
 **File patterns** (glob syntax):
 - `**/.claude/skills/*/SKILL.md` - All SKILL.md files in any skill directory
@@ -1213,6 +1222,14 @@ If legitimate prompts are being blocked, you have several options:
   }
 }
 ```
+
+**Why both are needed:**
+- `ignore_tools` covers skill execution (PreToolUse + PostToolUse)
+- `ignore_files` covers direct file access (Read tool, not skill execution)
+- Together they handle all access patterns:
+  - ✅ Skill:code-review execution → `ignore_tools` handles it
+  - ✅ Read tool accessing SKILL.md → `ignore_files` handles it
+  - ✅ Bash cat SKILL.md → `ignore_files` doesn't help (no file_path), but rare edge case
 
 **Method 2: Allowlist Patterns (Content-Based)**
 

--- a/README.md
+++ b/README.md
@@ -390,14 +390,18 @@ cd ~/project/secrets && touch .ai-read-deny
     "sensitivity": "medium",
     "allowlist_patterns": ["test:.*"],
     "ignore_tools": ["Skill:code-review"],
-    "ignore_files": ["**/.claude/skills/*/SKILL.md"]
+    "ignore_files": [
+      "**/.claude/skills/*/SKILL.md",
+      "**/.claude/projects/**/tool-results/**"
+    ]
   }
 }
 ```
 
 **NEW in v1.4.0:**
 - `ignore_tools` - Skip detection for specific tools (e.g., `"Skill:code-review"`, `"mcp__*"`)
-- `ignore_files` - Skip detection for specific files (e.g., `"**/.claude/skills/*/SKILL.md"`)
+- `ignore_files` - Skip detection for specific files (e.g., `"**/.claude/skills/*/SKILL.md"`, `"**/.claude/projects/**/tool-results/**"`)
+- Recommended: Include both skill files AND tool-results to prevent false positives from cached outputs
 - See [False Positives](#prompt-injection-false-positives) for detailed usage
 
 ### 🔒 Secret Scanning
@@ -1183,6 +1187,7 @@ If legitimate prompts are being blocked, you have several options:
     ],
     "ignore_files": [
       "**/.claude/skills/*/SKILL.md",   // All skill documentation
+      "**/.claude/projects/**/tool-results/**",  // Cached tool results
       "**/CLAUDE.md",                    // Project instructions
       "**/AGENTS.md"                     // Agent instructions
     ]
@@ -1207,6 +1212,7 @@ If legitimate prompts are being blocked, you have several options:
 
 **File patterns** (glob syntax):
 - `**/.claude/skills/*/SKILL.md` - All SKILL.md files in any skill directory
+- `**/.claude/projects/**/tool-results/**` - Cached tool outputs (prevents re-scanning)
 - `**/tests/**/*.md` - All markdown files in test directories
 - `~/Documents/security-*.md` - Files in home directory (~ expands)
 - `*` matches any characters except `/`
@@ -1218,7 +1224,10 @@ If legitimate prompts are being blocked, you have several options:
 {
   "prompt_injection": {
     "ignore_tools": ["Skill:code-review"],
-    "ignore_files": ["**/.claude/skills/*/SKILL.md"]
+    "ignore_files": [
+      "**/.claude/skills/code-review/**",        // Skill files
+      "**/.claude/projects/**/tool-results/**"   // Cached tool outputs
+    ]
   }
 }
 ```
@@ -1229,6 +1238,7 @@ If legitimate prompts are being blocked, you have several options:
 - Together they handle all access patterns:
   - ✅ Skill:code-review execution → `ignore_tools` handles it
   - ✅ Read tool accessing SKILL.md → `ignore_files` handles it
+  - ✅ Read tool accessing cached tool results → `ignore_files` handles it
   - ✅ Bash cat SKILL.md → `ignore_files` doesn't help (no file_path), but rare edge case
 
 **Method 2: Allowlist Patterns (Content-Based)**

--- a/examples/ignore-tools-config.json
+++ b/examples/ignore-tools-config.json
@@ -9,6 +9,7 @@
     ],
     "ignore_files": [
       "**/.claude/skills/*/SKILL.md",
+      "**/.claude/projects/**/tool-results/**",
       "**/CLAUDE.md",
       "**/AGENTS.md"
     ]

--- a/examples/secret-scanning-ignore-config.json
+++ b/examples/secret-scanning-ignore-config.json
@@ -15,6 +15,9 @@
   "prompt_injection": {
     "enabled": true,
     "ignore_tools": ["Skill:code-review"],
-    "ignore_files": ["**/.claude/skills/*/SKILL.md"]
+    "ignore_files": [
+      "**/.claude/skills/*/SKILL.md",
+      "**/.claude/projects/**/tool-results/**"
+    ]
   }
 }

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -1623,7 +1623,11 @@ def process_hook_input():
                 logging.warning("Could not extract file content, allowing operation")
                 return format_response(ide_type, has_secrets=False, hook_event=hook_event)
 
-            logging.info(f"Scanning file '{filename}' for secrets...")
+            # Log with full path for debugging false positives
+            if file_path:
+                logging.info(f"Scanning file '{filename}' ({file_path}) for secrets...")
+            else:
+                logging.info(f"Scanning file '{filename}' for secrets...")
 
         else:
             # Prompt hook - scan the user's prompt
@@ -1655,12 +1659,15 @@ def process_hook_input():
                     if is_injection:
                         # Prompt injection detected - block operation
                         if ide_type != IDEType.CURSOR:
-                            logging.warning("Prompt injection detected, blocking operation")
+                            if file_path:
+                                logging.warning(f"Prompt injection detected in {file_path}, blocking operation")
+                            else:
+                                logging.warning("Prompt injection detected, blocking operation")
 
                         # Log prompt injection violation
                         _log_prompt_injection_violation(
                             filename,
-                            context={"ide_type": ide_type.value, "hook_event": hook_event}
+                            context={"ide_type": ide_type.value, "hook_event": hook_event, "file_path": file_path}
                         )
 
                         return format_response(ide_type, has_secrets=True, error_message=injection_error, hook_event=hook_event)
@@ -1702,7 +1709,10 @@ def process_hook_input():
 
             # No secrets found, allow operation
             if hook_event == "pretooluse":
-                logging.info(f"✓ No secrets detected in file '{filename}'")
+                if file_path:
+                    logging.info(f"✓ No secrets detected in file '{filename}' ({file_path})")
+                else:
+                    logging.info(f"✓ No secrets detected in file '{filename}'")
             else:
                 logging.info("✓ No secrets detected in prompt")
         elif secret_config and ide_type != IDEType.CURSOR:

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -1520,30 +1520,41 @@ def process_hook_input():
                 # No output to scan - allow
                 return format_response(ide_type, has_secrets=False, hook_event=hook_event)
 
-            logging.info(f"Scanning {tool_name} output for secrets...")
+            # Create composite tool identifier for more granular ignore patterns
+            # This allows ignore_tools to match both PreToolUse (input) and PostToolUse (output)
+            # For Skill tool: "Skill:code-review"
+            # For MCP tools: already have composite name like "mcp__notebooklm__chat"
+            tool_identifier = tool_name
+            if "tool_use" in hook_data and isinstance(hook_data["tool_use"], dict):
+                tool_input = hook_data["tool_use"].get("input", {})
+                if tool_name == "Skill" and tool_input.get("skill"):
+                    tool_identifier = f"Skill:{tool_input['skill']}"
+                    logging.debug(f"Created composite identifier for PostToolUse: {tool_identifier}")
+
+            logging.info(f"Scanning {tool_identifier} output for secrets...")
 
             # Load secret scanning config for ignore lists
             secret_config = _load_secret_scanning_config()
             ignore_files = secret_config.get("ignore_files", []) if secret_config else []
             ignore_tools = secret_config.get("ignore_tools", []) if secret_config else []
 
-            # Check for secrets in the output
+            # Check for secrets in the output (use composite identifier for ignore matching)
             has_secrets, error_message = check_secrets_with_gitleaks(
-                tool_output, f"{tool_name}_output",
+                tool_output, f"{tool_identifier}_output",
                 context={"ide_type": ide_type.value, "hook_event": "posttooluse"},
-                tool_name=tool_name,
+                tool_name=tool_identifier,
                 ignore_files=ignore_files,
                 ignore_tools=ignore_tools
             )
 
             if has_secrets:
                 # Block output from reaching AI
-                logging.warning(f"Secrets detected in {tool_name} output")
+                logging.warning(f"Secrets detected in {tool_identifier} output")
                 return format_response(ide_type, has_secrets=True,
                                      error_message=error_message,
                                      hook_event=hook_event)
 
-            logging.info(f"✓ No secrets detected in {tool_name} output")
+            logging.info(f"✓ No secrets detected in {tool_identifier} output")
             return format_response(ide_type, has_secrets=False, hook_event=hook_event)
 
         # Extract tool name for PreToolUse events (needed for permissions and prompt injection)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

## Description
This PR adds `ignore_files` support to prompt injection detection in AI Guardian, allowing users to configure file patterns that should be excluded from prompt injection scanning. 

Key changes include:
- Added file path tracking to both prompt injection and secret scanning log outputs for better visibility
- Implemented correlation between `PostToolUse` and `PreToolUse` events for Skill tool ignore patterns, ensuring tool-specific ignore rules work correctly across the tool lifecycle
- Updated documentation with `tool-results` pattern examples for ignore_files configuration
- Added example configurations demonstrating ignore patterns for both tools and file paths

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Install/update the ai-guardian package: `pip install -e .`
3. Create a test configuration file with ignore_files patterns (use `examples/ignore-tools-config.json` as reference)
4. Run AI Guardian with the configuration and verify that files matching ignore patterns are excluded from prompt injection detection
5. Verify that file paths now appear in prompt injection and secret scanning log messages
6. Test Skill tool usage to confirm PreToolUse/PostToolUse correlation properly applies ignore_tools patterns

### Scenarios tested
- Verified ignore_files patterns correctly exclude matching files from prompt injection scanning
- Confirmed file paths are logged in both prompt injection and secret scanning outputs
- Tested Skill tool ignore patterns with correlated PreToolUse and PostToolUse events

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: