### PR TITLE
itdove/ai-guardian#88: Improve Policy Blocking Messages: Add Clear Reason and 'Blocked by Policy' Notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example configuration files: `examples/ignore-tools-config.json`, `examples/secret-scanning-ignore-config.json`
 
 ### Changed
+- **Improved policy blocking messages** (Issue #88)
+  - Added "🚨 BLOCKED BY POLICY" header to all tool denial messages
+  - Log messages now include specific reason for blocking:
+    - Before: `"Tool 'Bash' blocked by policy"`
+    - After: `"🚨 BLOCKED BY POLICY: Tool 'Bash' - Critical file protected: ai-guardian config"`
+  - Added explicit anti-workaround language to prevent AI agents from retrying:
+    - "DO NOT attempt workarounds - the protection is intentional"
+    - "DO NOT attempt workarounds - contact the system administrator if access is needed"
+  - Error messages now clearly explain WHY operations are blocked
+  - New `_extract_block_reason()` helper extracts concise reasons for logging:
+    - "Critical file protected: ai-guardian config"
+    - "Matched deny pattern: *.env"
+    - "No permission rule configured"
+    - "Not in allow list"
+  - Comprehensive test coverage: 10 new tests in `test_block_reason_extraction.py`
 - **Improved logging for debugging false positives**
   - Log messages now include full file paths (not just filenames)
   - Before: `"Scanning file 'SKILL.md' for secrets..."`

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -761,6 +761,51 @@ def _load_secret_scanning_config():
         return None
 
 
+def _extract_block_reason(error_message: str) -> str:
+    """
+    Extract a concise reason from error message for logging.
+
+    Args:
+        error_message: The full error message from policy checker
+
+    Returns:
+        str: Concise reason suitable for log messages
+
+    Examples:
+        - "Critical file protected: ai-guardian config"
+        - "Matched deny pattern: *.env"
+        - "No permission rule"
+    """
+    import re
+
+    if "CRITICAL FILE PROTECTED" in error_message:
+        if "ai-guardian configuration" in error_message:
+            return "Critical file protected: ai-guardian config"
+        elif "Repository source file" in error_message:
+            return "Critical file protected: source code"
+        elif "Directory protection marker" in error_message:
+            return "Critical file protected: .ai-read-deny marker"
+        else:
+            return "Critical file protected"
+
+    elif "matched deny pattern:" in error_message:
+        # Extract the pattern
+        match = re.search(r'matched deny pattern: ([^\n]+)', error_message)
+        if match:
+            pattern = match.group(1).strip()
+            return f"Matched deny pattern: {pattern}"
+        return "Matched deny pattern"
+
+    elif "no permission rule" in error_message:
+        return "No permission rule configured"
+
+    elif "not in allow list" in error_message:
+        return "Not in allow list"
+
+    else:
+        return "Policy violation"
+
+
 def _is_ai_guardian_test_file(file_path):
     """
     Check if a file path is an ai-guardian project test file.
@@ -1597,7 +1642,9 @@ def process_hook_input():
                     is_allowed, error_message, checked_tool_name = policy_checker.check_tool_allowed(hook_data)
 
                     if not is_allowed:
-                        logging.warning(f"Tool '{checked_tool_name}' blocked by policy")
+                        # Extract reason summary for logging
+                        reason_summary = _extract_block_reason(error_message) if error_message else "policy violation"
+                        logging.warning(f"🚨 BLOCKED BY POLICY: Tool '{checked_tool_name}' - {reason_summary}")
                         return format_response(ide_type, has_secrets=True, error_message=error_message, hook_event=hook_event)
 
                     if checked_tool_name and ide_type != IDEType.CURSOR:

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -785,6 +785,7 @@ class ToolPolicyChecker:
 
         msg = (
             f"\n{'='*70}\n"
+            f"🚨 BLOCKED BY POLICY\n"
             f"🚫 TOOL ACCESS DENIED\n"
             f"{'='*70}\n\n"
             f"Tool: {tool_name}\n"
@@ -828,7 +829,9 @@ class ToolPolicyChecker:
         msg += '      }\n'
         msg += '    ]\n'
         msg += '  }\n\n'
-        msg += "Or ask your administrator to update the enterprise policy.\n"
+        msg += "Or ask your administrator to update the enterprise policy.\n\n"
+        msg += "This permission rule is configured to protect your system.\n"
+        msg += "DO NOT attempt workarounds - contact the system administrator if access is needed.\n"
         msg += f"{'='*70}\n"
 
         return msg
@@ -888,6 +891,7 @@ class ToolPolicyChecker:
 
         base_message = (
             f"\n{'='*70}\n"
+            f"🚨 BLOCKED BY POLICY\n"
             f"🔒 CRITICAL FILE PROTECTED\n"
             f"{'='*70}\n\n"
             f"This file is protected by ai-guardian and cannot be modified.\n\n"
@@ -900,7 +904,10 @@ class ToolPolicyChecker:
             diagnostic = self._diagnose_maintainer_bypass()
             return base_message + (
                 f"\nReason: Repository source file (maintainer bypass not available)\n\n"
-                f"{diagnostic}\n"
+                f"{diagnostic}\n\n"
+                f"This protection prevents AI agents from bypassing security controls.\n"
+                f"DO NOT attempt workarounds - the protection is intentional.\n\n"
+                f"To edit these files, use your text editor manually.\n"
                 f"{'='*70}\n"
             )
 
@@ -928,6 +935,7 @@ class ToolPolicyChecker:
                 f"  • .ai-read-deny marker files (directory protection)\n\n"
                 f"This protection cannot be disabled via configuration.\n"
                 f"It ensures directory protection cannot be bypassed by AI agents.\n\n"
+                f"DO NOT attempt workarounds - the protection is intentional.\n\n"
                 f"To remove directory protection, delete .ai-read-deny manually.\n"
                 f"\n{'='*70}\n"
             )
@@ -941,6 +949,7 @@ class ToolPolicyChecker:
                 f"  • .ai-read-deny marker files (directory protection)\n\n"
                 f"This protection cannot be disabled via configuration.\n"
                 f"It ensures ai-guardian cannot be bypassed by AI agents.\n\n"
+                f"DO NOT attempt workarounds - the protection is intentional.\n\n"
                 f"To edit these files, use your text editor manually.\n"
                 f"\n{'='*70}\n"
             )

--- a/tests/test_block_reason_extraction.py
+++ b/tests/test_block_reason_extraction.py
@@ -1,0 +1,200 @@
+"""
+Unit tests for policy blocking message improvements (Issue #88)
+
+Tests that:
+- _extract_block_reason() correctly extracts concise reasons from error messages
+- Log messages include the specific reason for blocking
+- Error messages include "🚨 BLOCKED BY POLICY" header
+- Anti-workaround language is present in denial messages
+"""
+
+import unittest
+from ai_guardian import _extract_block_reason
+
+
+class BlockReasonExtractionTest(unittest.TestCase):
+    """Test suite for _extract_block_reason() function"""
+
+    def test_extract_critical_file_ai_guardian_config(self):
+        """Should extract 'Critical file protected: ai-guardian config' from immutable deny message"""
+        error_message = """
+======================================================================
+🚨 BLOCKED BY POLICY
+🔒 CRITICAL FILE PROTECTED
+======================================================================
+
+This file is protected by ai-guardian and cannot be modified.
+
+File: ~/.config/ai-guardian/ai-guardian.json
+Tool: Edit
+
+Reason: Critical security configuration
+
+Protected files:
+  • ai-guardian configuration files
+  • IDE hook configuration (Claude, Cursor)
+  • ai-guardian package source code
+  • .ai-read-deny marker files (directory protection)
+
+This protection cannot be disabled via configuration.
+It ensures ai-guardian cannot be bypassed by AI agents.
+
+DO NOT attempt workarounds - the protection is intentional.
+
+To edit these files, use your text editor manually.
+======================================================================
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Critical file protected: ai-guardian config")
+
+    def test_extract_critical_file_source_code(self):
+        """Should extract 'Critical file protected: source code' from source file deny"""
+        error_message = """
+======================================================================
+🚨 BLOCKED BY POLICY
+🔒 CRITICAL FILE PROTECTED
+======================================================================
+
+This file is protected by ai-guardian and cannot be modified.
+
+File: ~/ai-guardian/src/ai_guardian/__init__.py
+Tool: Edit
+
+Reason: Repository source file (maintainer bypass not available)
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Critical file protected: source code")
+
+    def test_extract_critical_file_marker(self):
+        """Should extract 'Critical file protected: .ai-read-deny marker' from marker file deny"""
+        error_message = """
+======================================================================
+🚨 BLOCKED BY POLICY
+🔒 CRITICAL FILE PROTECTED
+======================================================================
+
+This file is protected by ai-guardian and cannot be modified.
+
+File: ~/secrets/.ai-read-deny
+Tool: Edit
+
+Reason: Directory protection marker
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Critical file protected: .ai-read-deny marker")
+
+    def test_extract_matched_deny_pattern(self):
+        """Should extract pattern from 'matched deny pattern' message"""
+        error_message = """
+======================================================================
+🚨 BLOCKED BY POLICY
+🚫 TOOL ACCESS DENIED
+======================================================================
+
+Tool: Read
+File Path: ~/secrets/production.env
+Blocked by: matched deny pattern: *.env
+Matcher: Read
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Matched deny pattern: *.env")
+
+    def test_extract_no_permission_rule(self):
+        """Should extract 'No permission rule configured' from no rule message"""
+        error_message = """
+======================================================================
+🚨 BLOCKED BY POLICY
+🚫 TOOL ACCESS DENIED
+======================================================================
+
+Tool: Skill
+Skill Name: unknown-skill
+Blocked by: no permission rule
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "No permission rule configured")
+
+    def test_extract_not_in_allow_list(self):
+        """Should extract 'Not in allow list' from allow list denial"""
+        error_message = """
+======================================================================
+🚨 BLOCKED BY POLICY
+🚫 TOOL ACCESS DENIED
+======================================================================
+
+Tool: Skill
+Skill Name: daf-unknown
+Blocked by: not in allow list
+Matcher: Skill
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Not in allow list")
+
+    def test_extract_unknown_reason(self):
+        """Should return 'Policy violation' for unknown error format"""
+        error_message = "Some unknown error format"
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Policy violation")
+
+    def test_extract_complex_deny_pattern(self):
+        """Should extract complex patterns with special characters"""
+        error_message = """
+Blocked by: matched deny pattern: */.config/ai-guardian/*
+"""
+        reason = _extract_block_reason(error_message)
+        self.assertEqual(reason, "Matched deny pattern: */.config/ai-guardian/*")
+
+
+class PolicyBlockedHeaderTest(unittest.TestCase):
+    """Test suite for 🚨 BLOCKED BY POLICY header in error messages"""
+
+    def test_deny_message_has_blocked_header(self):
+        """Tool deny messages should include 🚨 BLOCKED BY POLICY header"""
+        from ai_guardian.tool_policy import ToolPolicyChecker
+
+        config = {
+            "permissions": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": ["daf-*"]
+                }
+            ]
+        }
+
+        policy_checker = ToolPolicyChecker(config=config)
+        hook_data = {
+            "tool_name": "Skill",
+            "tool_input": {"skill": "blocked-skill"}
+        }
+
+        allowed, error_msg, _ = policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(allowed)
+        self.assertIn("🚨 BLOCKED BY POLICY", error_msg)
+        self.assertIn("DO NOT attempt workarounds", error_msg)
+
+    def test_immutable_deny_message_has_blocked_header(self):
+        """Immutable file deny messages should include 🚨 BLOCKED BY POLICY header"""
+        from ai_guardian.tool_policy import ToolPolicyChecker
+
+        policy_checker = ToolPolicyChecker()
+
+        # Test with ai-guardian config file (immutable)
+        hook_data = {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": "/home/user/.config/ai-guardian/ai-guardian.json"
+            }
+        }
+
+        allowed, error_msg, _ = policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(allowed)
+        self.assertIn("🚨 BLOCKED BY POLICY", error_msg)
+        self.assertIn("🔒 CRITICAL FILE PROTECTED", error_msg)
+        self.assertIn("DO NOT attempt workarounds", error_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -299,8 +299,10 @@ class ErrorMessageReadabilityTest(TestCase):
 
         # Verify formatting
         self.assertIn("="*70, error_msg, "Should have separator line")
+        self.assertIn("🚨 BLOCKED BY POLICY", error_msg, "Should have policy blocked header")
         self.assertIn("🚫 TOOL ACCESS DENIED", error_msg, "Should have clear header")
         self.assertIn("Tool:", error_msg, "Should have labeled fields")
+        self.assertIn("DO NOT attempt workarounds", error_msg, "Should have anti-workaround language")
 
     @patch('ai_guardian._load_pattern_server_config')
     def test_secret_error_message_has_proper_formatting(self, mock_pattern_config):


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR improves the policy blocking messages in AI Guardian by adding clear reasons for why tools are blocked and introducing a "blocked-by-policy" notation to make policy violations more transparent and debuggable.

Changes include:
- Enhanced `tool_policy.py` to extract and include specific policy violation reasons in error messages
- Added clear "blocked-by-policy" markers to help users and developers quickly identify when actions are prevented by policy rules
- Implemented reason extraction logic to provide actionable feedback instead of generic blocking messages
- Added comprehensive test coverage for block reason extraction and error message formatting

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Configure a policy that blocks specific tool usage (e.g., block certain MCP tools or file operations)
3. Trigger a tool invocation that violates the configured policy
4. Verify the error message includes:
   - A clear reason explaining why the tool was blocked
   - The "blocked-by-policy" notation for easy identification
5. Run the test suite: `pytest tests/test_block_reason_extraction.py tests/test_error_messages.py`
6. Verify all tests pass

### Scenarios tested
- Policy violation messages with various blocking patterns
- Block reason extraction from different policy rule types
- Error message formatting with "blocked-by-policy" notation
- Test coverage added in `test_block_reason_extraction.py` and `test_error_messages.py`

## Deployment considerations
- [x] This code change is ready for deployment on its own