### PR TITLE
fix: respect global action=log setting for .ai-read-deny markers (issue #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Bug #93: Directory rules ignore action=log setting and block instead**
+  - When `directory_rules.action` was set to "log", .ai-read-deny markers still blocked access
+  - Global action setting was not applied when no specific rule matched the path
+  - Fixed by returning global action even when no rules match (applies to .ai-read-deny markers)
+  - Now correctly allows access with warnings in log mode as intended
+  - Added comprehensive test coverage in `tests/test_directory_rules_log_mode_bug.py`
+
 - **Bug #94: Directory rules incorrectly parse Bash command text as file paths**
   - Bash commands were incorrectly treated as file paths in PreToolUse hooks
   - Error messages incorrectly showed "File: daf git create enhancement..." for Bash commands

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -493,7 +493,8 @@ def _check_directory_rules(file_path, config):
             directory_rules = [backward_compat_rule] + directory_rules
 
         if not directory_rules:
-            return None, None
+            # No rules, but global_action still applies to .ai-read-deny markers
+            return None, global_action
 
         # Convert file path to absolute path
         abs_file_path = os.path.abspath(os.path.expanduser(file_path))
@@ -552,8 +553,10 @@ def _check_directory_rules(file_path, config):
                     logging.warning(f"Error processing rule pattern '{pattern}': {e}")
                     continue
 
-        # Return decision and global action (applies to all rules)
-        return final_decision, global_action if final_decision else None
+        # Return decision and global action
+        # Note: global_action is returned even when no rule matches because
+        # it applies to ALL violations, including .ai-read-deny markers (issue #93)
+        return final_decision, global_action
 
     except Exception as e:
         logging.error(f"Error checking directory rules: {e}")

--- a/tests/test_bash_directory_rules.py
+++ b/tests/test_bash_directory_rules.py
@@ -139,8 +139,20 @@ class TestBashDirectoryRules(unittest.TestCase):
 
             stdin_input = json.dumps(hook_data)
 
+            # Mock config to use block mode (not log mode)
+            mock_config = {
+                "directory_rules": {
+                    "action": "block",
+                    "rules": []
+                }
+            }
+
             with patch('sys.stdin', StringIO(stdin_input)):
-                response = process_hook_input()
+                with patch('ai_guardian.ToolPolicyChecker') as mock_policy_cls:
+                    mock_policy = mock_policy_cls.return_value
+                    mock_policy.config = mock_config
+                    mock_policy.check_tool_allowed.return_value = (True, None, "Read")
+                    response = process_hook_input()
 
             # PreToolUse uses JSON response
             output = json.loads(response["output"])

--- a/tests/test_directory_blocking.py
+++ b/tests/test_directory_blocking.py
@@ -58,8 +58,16 @@ def test_directory_blocking():
         print("Testing directory blocking feature...")
         print("=" * 70)
 
+        # Use explicit config with block mode (not log mode)
+        test_config = {
+            "directory_rules": {
+                "action": "block",
+                "rules": []
+            }
+        }
+
         # Test 1: Allowed file should not be blocked
-        is_denied, denied_path, _ = check_directory_denied(allowed_file)
+        is_denied, denied_path, _ = check_directory_denied(allowed_file, test_config)
         assert not is_denied, f"FAIL: Allowed file was blocked"
         assert denied_path is None, f"FAIL: Allowed file has denied path"
         print(f"✓ Test 1 PASSED: Allowed file is accessible")
@@ -67,7 +75,7 @@ def test_directory_blocking():
         print(f"  Blocked: {is_denied}")
 
         # Test 2: File in denied directory should be blocked
-        is_denied, denied_path, _ = check_directory_denied(blocked_file)
+        is_denied, denied_path, _ = check_directory_denied(blocked_file, test_config)
         assert is_denied, f"FAIL: Denied file was not blocked"
         assert denied_path == denied_dir, f"FAIL: Wrong denied directory reported"
         print(f"✓ Test 2 PASSED: File in denied directory is blocked")
@@ -76,7 +84,7 @@ def test_directory_blocking():
         print(f"  Denied dir: {denied_path}")
 
         # Test 3: File in subdirectory of denied directory should be blocked
-        is_denied, denied_path, _ = check_directory_denied(deeply_blocked_file)
+        is_denied, denied_path, _ = check_directory_denied(deeply_blocked_file, test_config)
         assert is_denied, f"FAIL: Nested file in denied directory was not blocked"
         assert denied_path == denied_dir, f"FAIL: Wrong denied directory reported for nested file"
         print(f"✓ Test 3 PASSED: Nested file in denied directory is blocked")

--- a/tests/test_directory_rules_log_mode_bug.py
+++ b/tests/test_directory_rules_log_mode_bug.py
@@ -1,0 +1,113 @@
+"""
+Test for issue #93: Directory rules ignore action=log setting and block instead
+
+This test reproduces the bug where .ai-read-deny markers block access
+even when directory_rules has action: "log" and no specific rule matches the path.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from ai_guardian import check_directory_denied
+
+
+class DirectoryRulesLogModeBugTest(unittest.TestCase):
+    """Test for bug #93: action=log ignored when .ai-read-deny marker present"""
+
+    def test_marker_with_global_log_action_no_matching_rule(self):
+        """
+        Bug: When .ai-read-deny marker exists but no rule matches,
+        global action="log" should still apply (allow with warning).
+
+        Config: action="log" globally, but rules don't match this path
+        Expected: Allow access with warning
+        Actual (before fix): Blocks access
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create .ai-read-deny marker
+            marker = os.path.join(tmpdir, ".ai-read-deny")
+            Path(marker).touch()
+
+            test_file = os.path.join(tmpdir, "test.txt")
+            Path(test_file).touch()
+
+            # Global action is "log", but no rule matches this path
+            config = {
+                "directory_rules": {
+                    "action": "log",
+                    "rules": [
+                        {
+                            "mode": "deny",
+                            "paths": ["/some/other/path"]  # Doesn't match tmpdir
+                        }
+                    ]
+                }
+            }
+
+            is_denied, denied_dir, warn_msg = check_directory_denied(test_file, config)
+
+            # Should be allowed with warning (bug: currently blocks)
+            self.assertFalse(is_denied, "Log mode should allow access even with .ai-read-deny marker")
+            self.assertIsNone(denied_dir, "Should not be denied when action=log")
+            self.assertIsNotNone(warn_msg, "Should return warning message in log mode")
+            self.assertIn("log mode", warn_msg.lower())
+
+    def test_marker_with_global_log_action_empty_rules(self):
+        """
+        Bug: When .ai-read-deny marker exists with no rules defined,
+        global action="log" should apply (allow with warning).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create .ai-read-deny marker
+            marker = os.path.join(tmpdir, ".ai-read-deny")
+            Path(marker).touch()
+
+            test_file = os.path.join(tmpdir, "test.txt")
+            Path(test_file).touch()
+
+            # Global action is "log", no rules defined
+            config = {
+                "directory_rules": {
+                    "action": "log",
+                    "rules": []
+                }
+            }
+
+            is_denied, denied_dir, warn_msg = check_directory_denied(test_file, config)
+
+            # Should be allowed with warning
+            self.assertFalse(is_denied, "Log mode should allow access")
+            self.assertIsNone(denied_dir)
+            self.assertIsNotNone(warn_msg, "Should return warning message in log mode")
+
+    def test_marker_with_global_block_action_no_matching_rule(self):
+        """
+        Control test: With action="block" (default), .ai-read-deny should block.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create .ai-read-deny marker
+            marker = os.path.join(tmpdir, ".ai-read-deny")
+            Path(marker).touch()
+
+            test_file = os.path.join(tmpdir, "test.txt")
+            Path(test_file).touch()
+
+            # Global action is "block" (default)
+            config = {
+                "directory_rules": {
+                    "action": "block",
+                    "rules": []
+                }
+            }
+
+            is_denied, denied_dir, warn_msg = check_directory_denied(test_file, config)
+
+            # Should be blocked
+            self.assertTrue(is_denied, "Block mode should deny access with .ai-read-deny marker")
+            self.assertIsNotNone(denied_dir)
+            self.assertIsNone(warn_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #93: Directory rules now correctly respect the global `action: "log"` setting for `.ai-read-deny` markers.

### Problem

When `directory_rules.action` was set to "log", `.ai-read-deny` markers still blocked access instead of allowing with warnings. This occurred when:
- A `.ai-read-deny` marker was present
- No specific rule matched the path
- Global action was set to "log"

### Root Cause

The `_check_directory_rules()` function returned `(None, None)` when no rule matched, discarding the global action setting. Per the schema, the `action` field "Applies to ALL rules" including `.ai-read-deny` markers.

### Changes

1. **src/ai_guardian/__init__.py**:
   - Return `global_action` unconditionally from `_check_directory_rules()` (line 496 and 558)
   - Added explanatory comments about issue #93
   
2. **tests/test_directory_rules_log_mode_bug.py** (new):
   - Test for `.ai-read-deny` marker with global action="log" and no matching rule
   - Test for empty rules array with global action="log"
   - Control test for action="block" behavior
   
3. **tests/test_bash_directory_rules.py**:
   - Mock config to use `action: "block"` to isolate from user's global config
   
4. **tests/test_directory_blocking.py**:
   - Pass explicit config with `action: "block"` to isolate from user's global config

5. **CHANGELOG.md**:
   - Documented fix under "Fixed" section

## Test plan

### Steps to test
1. Pull down the PR
2. Run the new test: `pytest tests/test_directory_rules_log_mode_bug.py -v`
3. Run all tests: `pytest`
4. Manual test:
   - Create config with `directory_rules.action: "log"`
   - Create a directory with `.ai-read-deny` marker
   - Try to read a file from that directory
   - Should allow with warning (not block)

### Scenarios tested
- [x] .ai-read-deny marker with action="log" and no matching rule → allows with warning
- [x] .ai-read-deny marker with action="log" and empty rules → allows with warning
- [x] .ai-read-deny marker with action="block" → blocks (control test)
- [x] All existing tests pass (558 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>