### PR TITLE
itdove/ai-guardian#107: Unify config structure: move permissions_enabled into permissions object

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ ai-guardian tui
 The TUI uses a modern tab-based interface with separate tabs for each concern:
 
 1. **⚙️ Global Settings** - Global security feature toggles (NEW)
-   - Manage `permissions_enabled` with time-based toggles
+   - Manage permissions enforcement (`permissions.enabled`) with time-based toggles
    - Manage `secret_scanning` with time-based toggles
    - Support for temporary disabling with expiration timestamps
    - Visual status indicators and auto re-enabling

--- a/ai-guardian-example.json
+++ b/ai-guardian-example.json
@@ -18,84 +18,59 @@
   "_comment15": "No configuration can disable these protections - they are hardcoded",
   "_comment16": "====================================================================",
 
-  "permissions": [
-    {
-      "_comment": "Skills - must be explicitly allowed",
-      "matcher": "Skill",
-      "mode": "allow",
-      "patterns": [
-        "daf-*",
-        "gh-cli",
-        "git-cli",
-        "glab-cli",
-        "arc",
-        "claude-api",
-        "update-config"
-      ],
-      "_time_based_example": [
-        "daf-*",
-        {
-          "pattern": "debug-*",
-          "valid_until": "2026-04-13T12:00:00Z",
-          "_comment": "Temporary debug access until noon UTC"
-        },
-        {
-          "pattern": "experimental-*",
-          "valid_until": "2026-04-20T00:00:00Z",
-          "_comment": "Testing period ends April 20"
-        }
-      ],
-      "_immutable_example_remote_config": {
-        "_comment": "In remote config ONLY: Add immutable: true to prevent local override",
+  "permissions": {
+    "_comment": "NEW unified structure in v1.4.0: combines enabled flag and rules in one object",
+    "enabled": true,
+    "rules": [
+      {
+        "_comment": "Skills - must be explicitly allowed",
         "matcher": "Skill",
         "mode": "allow",
-        "patterns": ["daf-*", "gh-cli"],
-        "immutable": true,
-        "_explanation": "Local configs cannot add or modify Skill rules when immutable is true"
-      }
-    },
-    {
-      "_comment": "MCP tools - must be explicitly allowed (optional - can use settings.json)",
-      "matcher": "mcp__*",
-      "mode": "allow",
-      "patterns": [
-        "mcp__notebooklm-mcp__notebook_list",
-        "mcp__notebooklm-mcp__notebook_get",
-        "mcp__notebooklm-mcp__notebook_query",
-        "mcp__notebooklm-mcp__source_add",
-        "mcp__atlassian__getJiraIssue",
-        "mcp__atlassian__searchJiraIssuesUsingJql"
-      ]
-    },
-    {
-      "_comment": "Enterprise restrictions - block dangerous Bash operations",
-      "matcher": "Bash",
-      "mode": "deny",
-      "patterns": [
-        "*rm -rf*",
-        "*mkfs*",
-        "*dd if=*"
-      ],
-      "_immutable_example_remote_config": {
-        "_comment": "In remote config: Prevent local configs from allowing dangerous commands",
+        "patterns": [
+          "daf-*",
+          "gh-cli",
+          "git-cli",
+          "glab-cli",
+          "arc",
+          "claude-api",
+          "update-config"
+        ]
+      },
+      {
+        "_comment": "MCP tools - must be explicitly allowed",
+        "matcher": "mcp__*",
+        "mode": "allow",
+        "patterns": [
+          "mcp__notebooklm-mcp__notebook_list",
+          "mcp__notebooklm-mcp__notebook_get",
+          "mcp__notebooklm-mcp__notebook_query",
+          "mcp__notebooklm-mcp__source_add",
+          "mcp__atlassian__getJiraIssue",
+          "mcp__atlassian__searchJiraIssuesUsingJql"
+        ]
+      },
+      {
+        "_comment": "Block dangerous Bash operations",
         "matcher": "Bash",
         "mode": "deny",
-        "patterns": ["*rm -rf*", "*dd if=*"],
-        "immutable": true,
-        "_explanation": "Enterprise security requirement - cannot be overridden locally"
+        "patterns": [
+          "*rm -rf*",
+          "*mkfs*",
+          "*dd if=*"
+        ]
+      },
+      {
+        "_comment": "Block system directory writes",
+        "matcher": "Write",
+        "mode": "deny",
+        "patterns": [
+          "/etc/*",
+          "/sys/*",
+          "/proc/*"
+        ]
       }
-    },
-    {
-      "_comment": "Enterprise restrictions - block system directory writes",
-      "matcher": "Write",
-      "mode": "deny",
-      "patterns": [
-        "/etc/*",
-        "/sys/*",
-        "/proc/*"
-      ]
-    }
-  ],
+    ]
+  },
 
   "permissions_directories": {
     "_comment": "OPTIONAL/ADVANCED: Auto-discover from directories (most users should use remote_configs instead)",
@@ -128,19 +103,6 @@
     ],
     "refresh_interval_hours": 12,
     "expire_after_hours": 168
-  },
-
-  "permissions_enabled": {
-    "_comment": "NEW in v1.4.0: Global tool permissions enforcement control",
-    "_comment2": "Controls whether tool permissions (MCP/Skills) are enforced",
-    "_comment3": "Supports both boolean (permanent) and time-based (temporary) formats",
-    "enabled": true,
-    "_simple_format": "true (boolean - permanent enable/disable)",
-    "_extended_format_example": {
-      "value": false,
-      "disabled_until": "2026-04-13T18:00:00Z",
-      "reason": "Emergency debugging - production incident"
-    }
   },
 
   "secret_scanning": {
@@ -313,76 +275,28 @@
   },
 
   "_permission_format": {
-    "_comment": "Matcher-based permission format with mode:",
+    "_comment": "NEW unified structure in v1.4.0",
     "_structure": {
-      "matcher": "Tool name pattern (e.g., 'Skill', 'mcp__*', 'Bash', 'Write')",
-      "mode": "allow or deny",
-      "patterns": ["List of patterns to allow/deny (string or object with valid_until)"]
+      "permissions": {
+        "enabled": "boolean or {value, disabled_until, reason}",
+        "immutable": "boolean (remote configs only)",
+        "rules": [
+          {
+            "matcher": "Skill | mcp__* | Bash | Write | Read",
+            "mode": "allow | deny",
+            "patterns": ["pattern1", "pattern2"],
+            "immutable": "boolean (optional, per-rule)"
+          }
+        ]
+      }
     },
-    "_explanation": "Each rule is either an allow-list (mode: allow) or deny-list (mode: deny)",
-    "_precedence": "All deny rules checked first (from any source), then allow rules",
-    "_time_based_expiration": {
-      "_comment": "NEW in v1.3.0: Patterns support optional time-based expiration",
-      "_simple_format": "daf-*",
-      "_extended_format": {
+    "_time_based_patterns": {
+      "_simple": "daf-*",
+      "_expiring": {
         "pattern": "debug-*",
         "valid_until": "2026-04-13T12:00:00Z"
-      },
-      "_explanation": "Extended format adds optional valid_until field (ISO 8601 timestamp in UTC)",
-      "_behavior": "Expired patterns are automatically filtered out during permission checks",
-      "_fail_safe": "Invalid timestamps or missing fields default to non-expiring (permanent)"
-    },
-    "_examples": [
-      {
-        "matcher": "Skill",
-        "mode": "allow",
-        "patterns": ["daf-*", "gh-cli"],
-        "_explanation": "Allow skills: daf-* and gh-cli"
-      },
-      {
-        "matcher": "Skill",
-        "mode": "allow",
-        "patterns": [
-          "daf-*",
-          {
-            "pattern": "debug-*",
-            "valid_until": "2026-04-13T12:00:00Z",
-            "_comment": "Temporary debug access"
-          }
-        ],
-        "_explanation": "Mixed simple and time-limited patterns"
-      },
-      {
-        "matcher": "mcp__*",
-        "mode": "allow",
-        "patterns": ["mcp__notebooklm-mcp__*"],
-        "_explanation": "Allow all notebooklm MCP tools"
-      },
-      {
-        "matcher": "Bash",
-        "mode": "deny",
-        "patterns": ["*rm -rf*"],
-        "_explanation": "Block dangerous bash commands"
-      },
-      {
-        "matcher": "Bash",
-        "mode": "allow",
-        "patterns": [
-          {
-            "pattern": "*docker rm*",
-            "valid_until": "2026-04-13T15:00:00Z",
-            "_comment": "Container cleanup until 15:00 UTC"
-          }
-        ],
-        "_explanation": "Temporary permission for Docker cleanup"
-      },
-      {
-        "matcher": "Write",
-        "mode": "deny",
-        "patterns": ["/etc/*"],
-        "_explanation": "Block writes to /etc"
       }
-    ]
+    }
   },
 
   "_pattern_matching": {
@@ -402,99 +316,28 @@
     "4": "Remote configs (enterprise policy - highest priority)"
   },
 
-  "_immutability_feature": {
-    "_comment": "====================================================================",
-    "_comment2": "IMMUTABLE FLAG - Enterprise Policy Enforcement (NEW in Issue #67)",
-    "_comment3": "====================================================================",
-    "_overview": "Remote configs can mark sections/rules as immutable to prevent local override",
-    "_use_cases": {
-      "1": "Enterprise Security Compliance: Enforce mandatory skill allowlists",
-      "2": "Regulatory Requirements: Ensure prompt injection detection cannot be weakened",
-      "3": "Zero-Trust Environments: Centrally managed pattern servers",
-      "4": "Audit & Compliance: Provable policy enforcement"
+  "_immutability_examples": {
+    "_section_level": {
+      "permissions": {
+        "enabled": true,
+        "immutable": true,
+        "rules": [],
+        "_effect": "Locks entire permissions (enabled + all rules)"
+      }
     },
-    "_per_matcher_immutability": {
-      "_description": "Mark specific permission rules as immutable (by matcher)",
-      "_example": {
-        "permissions": [
+    "_rule_level": {
+      "permissions": {
+        "enabled": true,
+        "rules": [
           {
             "matcher": "Skill",
             "mode": "allow",
-            "patterns": ["daf-*", "gh-cli"],
+            "patterns": ["daf-*"],
             "immutable": true,
-            "_effect": "Local configs cannot add/modify Skill rules"
-          },
-          {
-            "matcher": "Bash",
-            "mode": "deny",
-            "patterns": ["*rm -rf*", "*dd if=*"],
-            "immutable": true,
-            "_effect": "Local configs cannot add/modify Bash rules"
+            "_effect": "Locks only Skill matcher, users can add MCP/Bash/Write rules"
           }
         ]
       }
-    },
-    "_section_immutability": {
-      "_description": "Mark entire sections as immutable",
-      "_example": {
-        "prompt_injection": {
-          "enabled": true,
-          "sensitivity": "high",
-          "detector": "heuristic",
-          "immutable": true,
-          "_effect": "Entire prompt_injection section cannot be overridden locally"
-        },
-        "pattern_server": {
-          "enabled": true,
-          "url": "https://company.com/patterns",
-          "immutable": true,
-          "_effect": "Pattern server config cannot be disabled or changed locally"
-        }
-      }
-    },
-    "_complete_remote_config_example": {
-      "_comment": "Example enterprise remote config with immutability",
-      "_url": "https://company.com/ai-guardian-policy.json",
-      "_config": {
-        "permissions": [
-          {
-            "matcher": "Skill",
-            "mode": "allow",
-            "patterns": ["daf-*", "gh-cli", "git-cli"],
-            "immutable": true
-          },
-          {
-            "matcher": "Bash",
-            "mode": "deny",
-            "patterns": ["*rm -rf*", "*dd if=*"],
-            "immutable": true
-          }
-        ],
-        "prompt_injection": {
-          "enabled": true,
-          "sensitivity": "high",
-          "detector": "heuristic",
-          "immutable": true
-        },
-        "pattern_server": {
-          "enabled": true,
-          "url": "https://company.com/patterns",
-          "auth": {
-            "method": "bearer",
-            "token_env": "COMPANY_PATTERN_TOKEN"
-          },
-          "immutable": true
-        }
-      },
-      "_behavior": {
-        "_allowed_locally": "Users can add MCP, Write, Read rules (not immutable)",
-        "_blocked_locally": [
-          "Cannot add/modify Skill or Bash rules (immutable)",
-          "Cannot change prompt_injection settings (immutable)",
-          "Cannot override pattern_server config (immutable)"
-        ]
-      }
-    },
-    "_backward_compatibility": "Existing configs without immutable field work unchanged (defaults to false)"
+    }
   }
 }

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -100,7 +100,7 @@ Manage global security feature toggles with time-based controls.
 
 #### Features
 
-**Tool Permissions Enforcement** (`permissions_enabled`)
+**Tool Permissions Enforcement** (`permissions.enabled`)
 - Controls whether AI Guardian enforces tool permission rules
 - When disabled, all tools are allowed without checks
 - Supports time-based temporary disabling
@@ -154,11 +154,15 @@ Each setting supports three operational modes:
 **Example configuration**:
 ```json
 {
-  "permissions_enabled": {
-    "value": false,
-    "valid_until": "2026-04-15T18:00:00Z"
+  "permissions": {
+    "enabled": {
+      "value": false,
+      "disabled_until": "2026-04-15T18:00:00Z"
+    }
   },
-  "secret_scanning": true
+  "secret_scanning": {
+    "enabled": true
+  }
 }
 ```
 
@@ -1199,14 +1203,21 @@ From lowest to highest priority:
 
 ```json
 {
-  "permissions_enabled": true,
-  "secret_scanning": {
-    "value": false,
-    "valid_until": "2026-04-15T18:00:00Z"
+  "permissions": {
+    "enabled": true,
+    "rules": [
+      {
+        "matcher": "Skill",
+        "mode": "allow",
+        "patterns": ["daf-*", "release", "gh-cli"]
+      }
+    ]
   },
-  "skills": {
-    "allow": ["daf-*", "release", "gh-cli"],
-    "deny": []
+  "secret_scanning": {
+    "enabled": {
+      "value": false,
+      "disabled_until": "2026-04-15T18:00:00Z"
+    }
   },
   "mcp_servers": {
     "allow": ["mcp__notebooklm-mcp__*"],

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -1084,7 +1084,15 @@ def _load_permissions_config():
         return None, error_msg
     if config is None:
         return None, None
-    return config.get("permissions_enabled"), None
+
+    # NEW unified structure in v1.4.0: permissions.enabled
+    permissions = config.get("permissions")
+    if isinstance(permissions, dict):
+        # Return the enabled field from the permissions object
+        return {"enabled": permissions.get("enabled", True)}, None
+
+    # Fallback: default to enabled
+    return {"enabled": True}, None
 
 
 def _load_secret_scanning_config():

--- a/src/ai_guardian/schemas/ai-guardian-config.schema.json
+++ b/src/ai_guardian/schemas/ai-guardian-config.schema.json
@@ -7,11 +7,35 @@
   "additionalProperties": true,
   "properties": {
     "permissions": {
-      "type": "array",
-      "description": "Permission rules for tools (Skills, MCP servers, built-in tools like Bash/Write/Read). Default: Built-in tools ALLOW, Skills and MCP servers BLOCK unless explicitly allowed.",
-      "items": {
-        "$ref": "#/definitions/permission_rule"
-      }
+      "type": "object",
+      "description": "Tool permissions configuration (NEW unified structure in v1.4.0). Controls whether AI Guardian enforces tool permission rules and defines the permission rules for tools (Skills, MCP servers, built-in tools like Bash/Write/Read). Default: Built-in tools ALLOW, Skills and MCP servers BLOCK unless explicitly allowed.",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Simple boolean format for permanent enable/disable"
+            },
+            {
+              "$ref": "#/definitions/time_based_feature"
+            }
+          ],
+          "default": true
+        },
+        "immutable": {
+          "type": "boolean",
+          "description": "If true, local configs cannot override this entire section. Used in remote configs to enforce enterprise policies.",
+          "default": false
+        },
+        "rules": {
+          "type": "array",
+          "description": "Permission rules for tools (Skills, MCP servers, built-in tools like Bash/Write/Read). Default: Built-in tools ALLOW, Skills and MCP servers BLOCK unless explicitly allowed.",
+          "items": {
+            "$ref": "#/definitions/permission_rule"
+          }
+        }
+      },
+      "additionalProperties": true
     },
     "permissions_directories": {
       "oneOf": [
@@ -77,30 +101,6 @@
           "minimum": 1
         }
       }
-    },
-    "permissions_enabled": {
-      "type": "object",
-      "description": "Global tool permissions enforcement control (NEW in v1.4.0). Object with 'enabled' property that supports boolean (permanent) or time-based (temporary) formats.",
-      "properties": {
-        "enabled": {
-          "oneOf": [
-            {
-              "type": "boolean",
-              "description": "Simple boolean format for permanent enable/disable"
-            },
-            {
-              "$ref": "#/definitions/time_based_feature"
-            }
-          ],
-          "default": true
-        },
-        "immutable": {
-          "type": "boolean",
-          "description": "If true, local configs cannot override this entire section. Used in remote configs to enforce enterprise policies.",
-          "default": false
-        }
-      },
-      "additionalProperties": true
     },
     "secret_scanning": {
       "type": "object",

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -761,25 +761,25 @@ class ToolPolicyChecker:
         Returns:
             list: List of matching permission rules (may be empty)
         """
-        permissions = self.config.get("permissions", [])
+        permissions = self.config.get("permissions", {})
 
-        # Handle old format (dict with deny/allow) - convert to new format
+        # New unified format: object with enabled, immutable, rules
         if isinstance(permissions, dict):
-            logger.debug("Converting old permissions format to new array format")
-            # Create a catch-all rule
-            return [{
-                "matcher": "*",
-                "allow": permissions.get("allow", []),
-                "deny": permissions.get("deny", [])
-            }]
-
-        # New format: array of rules
-        if not isinstance(permissions, list):
+            rules = permissions.get("rules", [])
+        # Legacy format: array of rules directly (pre-v1.4.0)
+        elif isinstance(permissions, list):
+            logger.debug("Legacy permissions format detected (array) - consider updating to new structure")
+            rules = permissions
+        else:
             logger.warning(f"Invalid permissions format: {type(permissions)}")
             return []
 
+        if not isinstance(rules, list):
+            logger.warning(f"Invalid permissions.rules format: {type(rules)}")
+            return []
+
         matching_rules = []
-        for rule in permissions:
+        for rule in rules:
             if not isinstance(rule, dict):
                 continue
 
@@ -1726,7 +1726,14 @@ class ToolPolicyChecker:
 
         for remote_config in remote_configs:
             permissions = remote_config.get("permissions", [])
-            for rule in permissions:
+            # Handle new unified structure (permissions is an object with rules)
+            if isinstance(permissions, dict):
+                rules = permissions.get("rules", [])
+            else:
+                # Legacy format (permissions is an array)
+                rules = permissions
+
+            for rule in rules:
                 if rule.get("immutable", False):
                     matcher = rule.get("matcher")
                     if matcher:
@@ -1753,7 +1760,7 @@ class ToolPolicyChecker:
             "pattern_server",
             "secret_scanning",
             "directory_exclusions",
-            "permissions_enabled"
+            "permissions"
         ]
 
         for remote_config in remote_configs:
@@ -1768,7 +1775,11 @@ class ToolPolicyChecker:
     def _get_defaults(self) -> Dict:
         """Get default empty configuration."""
         return {
-            "permissions": [],
+            "permissions": {
+                "enabled": True,
+                "immutable": False,
+                "rules": []
+            },
             "permissions_directories": {
                 "deny": [],
                 "allow": []
@@ -1944,8 +1955,48 @@ class ToolPolicyChecker:
                 continue
 
             if key == "permissions":
-                # Special handling for permissions array with immutability filtering
-                if isinstance(value, list):
+                # Special handling for permissions object with immutability filtering
+                if isinstance(value, dict):
+                    # New unified format: permissions is an object with enabled, immutable, rules
+                    base_permissions = result.get(key, {})
+                    if not isinstance(base_permissions, dict):
+                        base_permissions = {"enabled": True, "immutable": False, "rules": []}
+
+                    # Merge the object
+                    merged_permissions = base_permissions.copy()
+
+                    # Merge enabled field (if not immutable at section level)
+                    if "enabled" in value and key not in immutable_sections:
+                        merged_permissions["enabled"] = value["enabled"]
+
+                    # Merge immutable field (always take from override)
+                    if "immutable" in value:
+                        merged_permissions["immutable"] = value["immutable"]
+
+                    # Merge rules array with matcher-level immutability filtering
+                    if "rules" in value:
+                        override_rules = value["rules"]
+                        if isinstance(override_rules, list):
+                            # Filter out rules for immutable matchers
+                            filtered_rules = []
+                            for rule in override_rules:
+                                matcher = rule.get("matcher")
+                                if matcher in immutable_matchers:
+                                    logger.info(f"Skipping override for immutable matcher: {matcher}")
+                                else:
+                                    filtered_rules.append(rule)
+
+                            # Concatenate with existing rules
+                            existing_rules = merged_permissions.get("rules", [])
+                            if isinstance(existing_rules, list):
+                                merged_permissions["rules"] = existing_rules + filtered_rules
+                            else:
+                                merged_permissions["rules"] = filtered_rules
+
+                    result[key] = merged_permissions
+                elif isinstance(value, list):
+                    # Legacy format: permissions is array of rules directly (pre-v1.4.0)
+                    logger.debug("Legacy permissions array format in override - converting to new structure")
                     # Filter out rules for immutable matchers
                     filtered_rules = []
                     for rule in value:
@@ -1955,11 +2006,21 @@ class ToolPolicyChecker:
                         else:
                             filtered_rules.append(rule)
 
-                    # Merge filtered rules with existing ones
-                    if isinstance(result.get(key), list):
+                    # If base is new format (dict), merge into rules
+                    if isinstance(result.get(key), dict):
+                        base_permissions = result[key]
+                        existing_rules = base_permissions.get("rules", [])
+                        if isinstance(existing_rules, list):
+                            base_permissions["rules"] = existing_rules + filtered_rules
+                        else:
+                            base_permissions["rules"] = filtered_rules
+                        result[key] = base_permissions
+                    # If base is also legacy format (list), just concatenate
+                    elif isinstance(result.get(key), list):
                         result[key] = result[key] + filtered_rules
                     else:
-                        result[key] = filtered_rules
+                        # Base is missing or invalid - create new structure
+                        result[key] = {"enabled": True, "immutable": False, "rules": filtered_rules}
                 else:
                     result[key] = value
             elif key in result:
@@ -2166,13 +2227,28 @@ class ToolPolicyChecker:
             list_type: "allow" or "deny"
             items: List of patterns to add
         """
-        # Ensure permissions is a list
-        if "permissions" not in config or not isinstance(config["permissions"], list):
-            config["permissions"] = []
+        # Ensure permissions is the new unified structure
+        if "permissions" not in config:
+            config["permissions"] = {"enabled": True, "immutable": False, "rules": []}
+
+        permissions = config["permissions"]
+
+        # Handle new unified format
+        if isinstance(permissions, dict):
+            if "rules" not in permissions:
+                permissions["rules"] = []
+            rules = permissions["rules"]
+        # Legacy format: array directly
+        elif isinstance(permissions, list):
+            rules = permissions
+        else:
+            # Invalid format - create new structure
+            config["permissions"] = {"enabled": True, "immutable": False, "rules": []}
+            rules = config["permissions"]["rules"]
 
         # Find existing rule with this matcher and mode
         mode = list_type  # "allow" or "deny"
-        for rule in config["permissions"]:
+        for rule in rules:
             if rule.get("matcher") == matcher and rule.get("mode") == mode:
                 # Add to existing rule's patterns
                 if "patterns" not in rule:
@@ -2186,4 +2262,4 @@ class ToolPolicyChecker:
             "mode": mode,
             "patterns": items
         }
-        config["permissions"].append(new_rule)
+        rules.append(new_rule)

--- a/src/ai_guardian/tui/global_settings.py
+++ b/src/ai_guardian/tui/global_settings.py
@@ -101,13 +101,13 @@ class GlobalSettingsContent(Container):
                 self.app.notify(f"Error loading config: {e}", severity="error")
                 return
 
-        # Load permissions_enabled setting
-        permissions_enabled = config.get("permissions_enabled", {})
-        if isinstance(permissions_enabled, dict):
-            permissions_value = permissions_enabled.get("enabled", True)
+        # Load permissions.enabled setting (NEW unified structure in v1.4.0)
+        permissions = config.get("permissions", {})
+        if isinstance(permissions, dict):
+            permissions_value = permissions.get("enabled", True)
         else:
-            # Legacy format - just a boolean at top level
-            permissions_value = config.get("permissions_enabled", True)
+            # Default if permissions section doesn't exist
+            permissions_value = True
 
         # Load secret_scanning setting
         secret_scanning = config.get("secret_scanning", {})
@@ -214,12 +214,33 @@ class GlobalSettingsContent(Container):
             else:
                 config = {}
 
-            # Save in new format - always use object with enabled property
-            if isinstance(value, bool):
-                config[config_key] = {"enabled": value}
+            # NEW unified structure in v1.4.0: save to nested structure
+            if config_key == "permissions_enabled":
+                # Save to permissions.enabled instead
+                if "permissions" not in config or not isinstance(config["permissions"], dict):
+                    config["permissions"] = {"enabled": True, "rules": []}
+
+                # Update the enabled field
+                if isinstance(value, bool):
+                    config["permissions"]["enabled"] = value
+                else:
+                    config["permissions"]["enabled"] = value
+            elif config_key == "secret_scanning":
+                # Secret scanning keeps its own top-level structure
+                if isinstance(value, bool):
+                    if "secret_scanning" not in config or not isinstance(config["secret_scanning"], dict):
+                        config["secret_scanning"] = {}
+                    config["secret_scanning"]["enabled"] = value
+                else:
+                    if "secret_scanning" not in config or not isinstance(config["secret_scanning"], dict):
+                        config["secret_scanning"] = {}
+                    config["secret_scanning"]["enabled"] = value
             else:
-                # Time-based format
-                config[config_key] = {"enabled": value}
+                # Other settings (if any in the future)
+                if isinstance(value, bool):
+                    config[config_key] = {"enabled": value}
+                else:
+                    config[config_key] = {"enabled": value}
 
             with open(config_path, 'w', encoding='utf-8') as f:
                 json.dump(config, f, indent=2)

--- a/src/ai_guardian/tui/mcp_servers.py
+++ b/src/ai_guardian/tui/mcp_servers.py
@@ -281,8 +281,13 @@ class MCPServersContent(Container):
             try:
                 with open(config_path, 'r', encoding='utf-8') as f:
                     config = json.load(f)
+                    # NEW unified structure in v1.4.0
+                    permissions_obj = config.get("permissions", {})
+                    if isinstance(permissions_obj, dict):
+                        all_permissions = permissions_obj.get("rules", [])
+                    else:
+                        all_permissions = permissions_obj if isinstance(permissions_obj, list) else []
                     # Filter only MCP permissions
-                    all_permissions = config.get("permissions", [])
                     permissions = [p for p in all_permissions if p.get("matcher", "").startswith("mcp__")]
             except Exception as e:
                 self.app.notify(f"Error loading permissions: {e}", severity="error")
@@ -342,7 +347,12 @@ class MCPServersContent(Container):
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
-                all_permissions = config.get("permissions", [])
+                # NEW unified structure in v1.4.0
+                permissions_obj = config.get("permissions", {})
+                if isinstance(permissions_obj, dict):
+                    all_permissions = permissions_obj.get("rules", [])
+                else:
+                    all_permissions = permissions_obj if isinstance(permissions_obj, list) else []
                 mcp_permissions = [p for p in all_permissions if p.get("matcher", "").startswith("mcp__")]
 
             if index >= len(mcp_permissions):
@@ -362,7 +372,11 @@ class MCPServersContent(Container):
                                 break
                             mcp_count += 1
 
-                    config["permissions"] = all_permissions
+                    # Save back to new structure
+                    if isinstance(config.get("permissions"), dict):
+                        config["permissions"]["rules"] = all_permissions
+                    else:
+                        config["permissions"] = {"enabled": True, "rules": all_permissions}
 
                     with open(config_path, 'w', encoding='utf-8') as f:
                         json.dump(config, f, indent=2)
@@ -387,7 +401,12 @@ class MCPServersContent(Container):
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
-                all_permissions = config.get("permissions", [])
+                # NEW unified structure in v1.4.0
+                permissions_obj = config.get("permissions", {})
+                if isinstance(permissions_obj, dict):
+                    all_permissions = permissions_obj.get("rules", [])
+                else:
+                    all_permissions = permissions_obj if isinstance(permissions_obj, list) else []
 
             # Find and remove the MCP permission
             mcp_count = 0
@@ -398,7 +417,11 @@ class MCPServersContent(Container):
                         break
                     mcp_count += 1
 
-            config["permissions"] = all_permissions
+            # Save back to new structure
+            if isinstance(config.get("permissions"), dict):
+                config["permissions"]["rules"] = all_permissions
+            else:
+                config["permissions"] = {"enabled": True, "rules": all_permissions}
 
             with open(config_path, 'w', encoding='utf-8') as f:
                 json.dump(config, f, indent=2)

--- a/src/ai_guardian/tui/permissions.py
+++ b/src/ai_guardian/tui/permissions.py
@@ -257,7 +257,13 @@ class PermissionsScreen(Screen):
             try:
                 with open(config_path, 'r', encoding='utf-8') as f:
                     config = json.load(f)
-                    permissions = config.get("permissions", [])
+                    # NEW unified structure in v1.4.0: permissions is object with rules array
+                    permissions_obj = config.get("permissions", {})
+                    if isinstance(permissions_obj, dict):
+                        permissions = permissions_obj.get("rules", [])
+                    else:
+                        # Legacy format: permissions is array directly
+                        permissions = permissions_obj if isinstance(permissions_obj, list) else []
             except Exception as e:
                 self.notify(f"Error loading permissions: {e}", severity="error")
 
@@ -311,7 +317,12 @@ class PermissionsScreen(Screen):
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
-                permissions = config.get("permissions", [])
+                # NEW unified structure in v1.4.0
+                permissions_obj = config.get("permissions", {})
+                if isinstance(permissions_obj, dict):
+                    permissions = permissions_obj.get("rules", [])
+                else:
+                    permissions = permissions_obj if isinstance(permissions_obj, list) else []
 
             if index >= len(permissions):
                 self.notify("Permission not found", severity="error")
@@ -322,7 +333,11 @@ class PermissionsScreen(Screen):
             def handle_result(updated_rule: Dict) -> None:
                 if updated_rule:
                     permissions[index] = updated_rule
-                    config["permissions"] = permissions
+                    # Save back to new structure
+                    if isinstance(config.get("permissions"), dict):
+                        config["permissions"]["rules"] = permissions
+                    else:
+                        config["permissions"] = {"enabled": True, "rules": permissions}
 
                     with open(config_path, 'w', encoding='utf-8') as f:
                         json.dump(config, f, indent=2)
@@ -347,7 +362,12 @@ class PermissionsScreen(Screen):
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
-                permissions = config.get("permissions", [])
+                # NEW unified structure in v1.4.0
+                permissions_obj = config.get("permissions", {})
+                if isinstance(permissions_obj, dict):
+                    permissions = permissions_obj.get("rules", [])
+                else:
+                    permissions = permissions_obj if isinstance(permissions_obj, list) else []
 
             if index >= len(permissions):
                 self.notify("Permission not found", severity="error")
@@ -355,7 +375,11 @@ class PermissionsScreen(Screen):
 
             # Remove the permission
             removed_rule = permissions.pop(index)
-            config["permissions"] = permissions
+            # Save back to new structure
+            if isinstance(config.get("permissions"), dict):
+                config["permissions"]["rules"] = permissions
+            else:
+                config["permissions"] = {"enabled": True, "rules": permissions}
 
             with open(config_path, 'w', encoding='utf-8') as f:
                 json.dump(config, f, indent=2)

--- a/src/ai_guardian/tui/skills.py
+++ b/src/ai_guardian/tui/skills.py
@@ -250,7 +250,12 @@ class SkillsContent(Container):
             try:
                 with open(config_path, 'r', encoding='utf-8') as f:
                     config = json.load(f)
-                    all_permissions = config.get("permissions", [])
+                    # NEW unified structure in v1.4.0
+                    permissions_obj = config.get("permissions", {})
+                    if isinstance(permissions_obj, dict):
+                        all_permissions = permissions_obj.get("rules", [])
+                    else:
+                        all_permissions = permissions_obj if isinstance(permissions_obj, list) else []
 
                     # Extract allow and deny patterns for Skill matcher
                     for perm in all_permissions:
@@ -392,7 +397,12 @@ class SkillsContent(Container):
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
 
-            all_permissions = config.get("permissions", [])
+            # NEW unified structure in v1.4.0
+            permissions_obj = config.get("permissions", {})
+            if isinstance(permissions_obj, dict):
+                all_permissions = permissions_obj.get("rules", [])
+            else:
+                all_permissions = permissions_obj if isinstance(permissions_obj, list) else []
 
             # Find and remove pattern
             for perm in all_permissions:
@@ -404,7 +414,11 @@ class SkillsContent(Container):
                         if not patterns:
                             all_permissions.remove(perm)
 
-                        config["permissions"] = all_permissions
+                        # Save back to new structure
+                        if isinstance(config.get("permissions"), dict):
+                            config["permissions"]["rules"] = all_permissions
+                        else:
+                            config["permissions"] = {"enabled": True, "rules": all_permissions}
 
                         with open(config_path, 'w', encoding='utf-8') as f:
                             json.dump(config, f, indent=2)

--- a/tests/fixtures/valid-config.json
+++ b/tests/fixtures/valid-config.json
@@ -1,68 +1,75 @@
 {
   "$schema": "https://raw.githubusercontent.com/itdove/ai-guardian/main/src/ai_guardian/schemas/ai-guardian-config.schema.json",
-  "permissions": [
-    {
-      "matcher": "Skill",
-      "mode": "allow",
-      "patterns": [
-        "daf-*",
-        "gh-cli",
-        "git-cli",
-        "glab-cli",
-        "arc",
-        "claude-api",
-        "update-config",
-        {
-          "pattern": "debug-*",
-          "valid_until": "2026-04-13T12:00:00Z"
-        },
-        {
-          "pattern": "experimental-*",
-          "valid_until": "2026-04-20T00:00:00Z"
-        }
-      ]
+  "permissions": {
+    "enabled": {
+      "value": false,
+      "disabled_until": "2026-04-13T18:00:00Z",
+      "reason": "Emergency debugging - production incident"
     },
-    {
-      "matcher": "mcp__*",
-      "mode": "allow",
-      "patterns": [
-        "mcp__notebooklm-mcp__notebook_list",
-        "mcp__notebooklm-mcp__notebook_get",
-        "mcp__notebooklm-mcp__notebook_query",
-        "mcp__notebooklm-mcp__source_add",
-        "mcp__atlassian__getJiraIssue",
-        "mcp__atlassian__searchJiraIssuesUsingJql"
-      ]
-    },
-    {
-      "matcher": "Bash",
-      "mode": "deny",
-      "patterns": [
-        "*rm -rf*",
-        "*mkfs*",
-        "*dd if=*"
-      ]
-    },
-    {
-      "matcher": "Bash",
-      "mode": "allow",
-      "patterns": [
-        {
-          "pattern": "*docker rm*",
-          "valid_until": "2026-04-13T15:00:00Z"
-        }
-      ]
-    },
-    {
-      "matcher": "Write",
-      "mode": "deny",
-      "patterns": [
-        "/etc/*",
-        "/sys/*",
-        "/proc/*"
-      ]
-    }
-  ],
+    "rules": [
+      {
+        "matcher": "Skill",
+        "mode": "allow",
+        "patterns": [
+          "daf-*",
+          "gh-cli",
+          "git-cli",
+          "glab-cli",
+          "arc",
+          "claude-api",
+          "update-config",
+          {
+            "pattern": "debug-*",
+            "valid_until": "2026-04-13T12:00:00Z"
+          },
+          {
+            "pattern": "experimental-*",
+            "valid_until": "2026-04-20T00:00:00Z"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__*",
+        "mode": "allow",
+        "patterns": [
+          "mcp__notebooklm-mcp__notebook_list",
+          "mcp__notebooklm-mcp__notebook_get",
+          "mcp__notebooklm-mcp__notebook_query",
+          "mcp__notebooklm-mcp__notebook_add",
+          "mcp__atlassian__getJiraIssue",
+          "mcp__atlassian__searchJiraIssuesUsingJql"
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "mode": "deny",
+        "patterns": [
+          "*rm -rf*",
+          "*mkfs*",
+          "*dd if=*"
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "mode": "allow",
+        "patterns": [
+          {
+            "pattern": "*docker rm*",
+            "valid_until": "2026-04-13T15:00:00Z"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "mode": "deny",
+        "patterns": [
+          "/etc/*",
+          "/sys/*",
+          "/proc/*"
+        ]
+      }
+    ]
+  },
   "permissions_directories": {
     "deny": [],
     "allow": [
@@ -88,13 +95,6 @@
     ],
     "refresh_interval_hours": 12,
     "expire_after_hours": 168
-  },
-  "permissions_enabled": {
-    "enabled": {
-      "value": false,
-      "disabled_until": "2026-04-13T18:00:00Z",
-      "reason": "Emergency debugging - production incident"
-    }
   },
   "secret_scanning": {
     "enabled": {

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -15,13 +15,16 @@ from ai_guardian.tool_policy import ToolPolicyChecker
 def test_valid_config_loads_successfully():
     """Test that a valid configuration loads without errors."""
     valid_config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "allow",
-                "patterns": ["daf-*", "gh-cli"]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": ["daf-*", "gh-cli"]
+                }
+            ]
+        }
     }
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -33,6 +36,7 @@ def test_valid_config_loads_successfully():
         config = checker._load_json_file(Path(temp_path), "test")
         assert config is not None
         assert "permissions" in config
+        assert "rules" in config["permissions"]
     finally:
         Path(temp_path).unlink()
 
@@ -40,13 +44,16 @@ def test_valid_config_loads_successfully():
 def test_invalid_mode_rejected_at_load():
     """Test that invalid permission mode is rejected at load time."""
     invalid_config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "invalid_mode",  # Invalid!
-                "patterns": ["daf-*"]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "invalid_mode",  # Invalid!
+                    "patterns": ["daf-*"]
+                }
+            ]
+        }
     }
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -86,12 +93,15 @@ def test_invalid_detector_rejected_at_load():
 def test_missing_required_fields_rejected_at_load():
     """Test that missing required fields are rejected at load time."""
     invalid_config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                # Missing "mode" and "patterns" (required)
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    # Missing "mode" and "patterns" (required)
+                }
+            ]
+        }
     }
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -127,25 +137,25 @@ def test_empty_config_is_valid():
 def test_complex_valid_config_loads():
     """Test that a complex valid configuration loads successfully."""
     complex_config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "allow",
-                "patterns": [
-                    "daf-*",
-                    {
-                        "pattern": "debug-*",
-                        "valid_until": "2026-04-13T12:00:00Z"
-                    }
-                ]
-            }
-        ],
-        "permissions_enabled": {
+        "permissions": {
             "enabled": {
                 "value": False,
                 "disabled_until": "2026-04-13T18:00:00Z",
                 "reason": "Emergency debugging"
-            }
+            },
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": [
+                        "daf-*",
+                        {
+                            "pattern": "debug-*",
+                            "valid_until": "2026-04-13T12:00:00Z"
+                        }
+                    ]
+                }
+            ]
         },
         "prompt_injection": {
             "enabled": True,
@@ -163,7 +173,6 @@ def test_complex_valid_config_loads():
         config = checker._load_json_file(Path(temp_path), "test")
         assert config is not None
         assert "permissions" in config
-        assert "permissions_enabled" in config
         assert "prompt_injection" in config
     finally:
         Path(temp_path).unlink()
@@ -172,20 +181,23 @@ def test_complex_valid_config_loads():
 def test_immutable_field_in_permissions_is_valid():
     """Test that immutable field in permission rules is valid (Issue #67)."""
     config_with_immutable = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "allow",
-                "patterns": ["daf-*"],
-                "immutable": True
-            },
-            {
-                "matcher": "Bash",
-                "mode": "deny",
-                "patterns": ["*rm -rf*"],
-                "immutable": False
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": ["daf-*"],
+                    "immutable": True
+                },
+                {
+                    "matcher": "Bash",
+                    "mode": "deny",
+                    "patterns": ["*rm -rf*"],
+                    "immutable": False
+                }
+            ]
+        }
     }
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -196,8 +208,8 @@ def test_immutable_field_in_permissions_is_valid():
         checker = ToolPolicyChecker()
         config = checker._load_json_file(Path(temp_path), "test")
         assert config is not None
-        assert config["permissions"][0]["immutable"] is True
-        assert config["permissions"][1]["immutable"] is False
+        assert config["permissions"]["rules"][0]["immutable"] is True
+        assert config["permissions"]["rules"][1]["immutable"] is False
     finally:
         Path(temp_path).unlink()
 

--- a/tests/test_immutable_configs.py
+++ b/tests/test_immutable_configs.py
@@ -23,25 +23,31 @@ class ImmutableConfigTest(TestCase):
         """Remote config with immutable matcher blocks local rules for that matcher"""
         # Simulate remote config with immutable Skill matcher
         remote_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*", "gh-cli"],
-                    "immutable": True
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*", "gh-cli"],
+                        "immutable": True
+                    }
+                ]
+            }
         }
 
         # Simulate local config trying to add more Skill rules
         local_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["my-custom-skill"]
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["my-custom-skill"]
+                    }
+                ]
+            }
         }
 
         # Create checker and merge configs
@@ -57,7 +63,9 @@ class ImmutableConfigTest(TestCase):
 
         # Verify: local Skill rule should be filtered out
         skill_patterns = []
-        for rule in result.get("permissions", []):
+        permissions_obj = result.get("permissions", {})
+        rules = permissions_obj.get("rules", []) if isinstance(permissions_obj, dict) else permissions_obj
+        for rule in rules:
             if rule.get("matcher") == "Skill":
                 skill_patterns.extend(rule.get("patterns", []))
 
@@ -70,25 +78,31 @@ class ImmutableConfigTest(TestCase):
         """Local configs can still add rules for non-immutable matchers"""
         # Remote config with immutable Skill matcher
         remote_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*"],
-                    "immutable": True
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*"],
+                        "immutable": True
+                    }
+                ]
+            }
         }
 
         # Local config adds MCP rules (not immutable)
         local_config = {
-            "permissions": [
-                {
-                    "matcher": "mcp__*",
-                    "mode": "allow",
-                    "patterns": ["mcp__notebooklm-mcp__*"]
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "mcp__*",
+                        "mode": "allow",
+                        "patterns": ["mcp__notebooklm-mcp__*"]
+                    }
+                ]
+            }
         }
 
         checker = ToolPolicyChecker()
@@ -99,7 +113,9 @@ class ImmutableConfigTest(TestCase):
 
         # Verify: MCP rule should be present (not immutable)
         mcp_found = False
-        for rule in result.get("permissions", []):
+        permissions_obj = result.get("permissions", {})
+        rules = permissions_obj.get("rules", []) if isinstance(permissions_obj, dict) else permissions_obj
+        for rule in rules:
             if rule.get("matcher") == "mcp__*":
                 mcp_found = True
                 assert "mcp__notebooklm-mcp__*" in rule.get("patterns", [])
@@ -109,35 +125,41 @@ class ImmutableConfigTest(TestCase):
     def test_multiple_immutable_matchers(self):
         """Multiple matchers can be marked as immutable"""
         remote_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*"],
-                    "immutable": True
-                },
-                {
-                    "matcher": "Bash",
-                    "mode": "deny",
-                    "patterns": ["*rm -rf*"],
-                    "immutable": True
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*"],
+                        "immutable": True
+                    },
+                    {
+                        "matcher": "Bash",
+                        "mode": "deny",
+                        "patterns": ["*rm -rf*"],
+                        "immutable": True
+                    }
+                ]
+            }
         }
 
         local_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["custom-*"]
-                },
-                {
-                    "matcher": "Bash",
-                    "mode": "allow",
-                    "patterns": ["*safe-command*"]
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["custom-*"]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "mode": "allow",
+                        "patterns": ["*safe-command*"]
+                    }
+                ]
+            }
         }
 
         checker = ToolPolicyChecker()
@@ -150,7 +172,9 @@ class ImmutableConfigTest(TestCase):
         result = checker._merge_configs(result, remote_config, set(), set())
 
         # Both Skill and Bash local rules should be filtered out
-        for rule in result.get("permissions", []):
+        permissions_obj = result.get("permissions", {})
+        rules = permissions_obj.get("rules", []) if isinstance(permissions_obj, dict) else permissions_obj
+        for rule in rules:
             if rule.get("matcher") == "Skill":
                 assert "custom-*" not in rule.get("patterns", [])
             if rule.get("matcher") == "Bash":
@@ -262,14 +286,17 @@ class ImmutableConfigTest(TestCase):
     def test_configs_without_immutable_field_work_unchanged(self):
         """Existing configs without immutable field work as before"""
         config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*"]
-                    # No immutable field
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*"]
+                        # No immutable field
+                    }
+                ]
+            }
         }
 
         checker = ToolPolicyChecker()
@@ -283,14 +310,17 @@ class ImmutableConfigTest(TestCase):
     def test_immutable_false_treated_as_non_immutable(self):
         """immutable: false is treated the same as missing field"""
         config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*"],
-                    "immutable": False
-                }
-            ],
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*"],
+                        "immutable": False
+                    }
+                ]
+            },
             "prompt_injection": {
                 "enabled": True,
                 "immutable": False
@@ -312,20 +342,23 @@ class ImmutableConfigTest(TestCase):
         """_get_immutable_matchers correctly identifies immutable matchers"""
         remote_configs = [
             {
-                "permissions": [
-                    {
-                        "matcher": "Skill",
-                        "mode": "allow",
-                        "patterns": ["daf-*"],
-                        "immutable": True
-                    },
-                    {
-                        "matcher": "Bash",
-                        "mode": "deny",
-                        "patterns": ["*rm -rf*"],
-                        "immutable": False
-                    }
-                ]
+                "permissions": {
+                    "enabled": True,
+                    "rules": [
+                        {
+                            "matcher": "Skill",
+                            "mode": "allow",
+                            "patterns": ["daf-*"],
+                            "immutable": True
+                        },
+                        {
+                            "matcher": "Bash",
+                            "mode": "deny",
+                            "patterns": ["*rm -rf*"],
+                            "immutable": False
+                        }
+                    ]
+                }
             }
         ]
 
@@ -368,14 +401,17 @@ class ImmutableConfigTest(TestCase):
     def test_immutable_field_validates_in_schema(self):
         """Configs with immutable field pass schema validation"""
         config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*"],
-                    "immutable": True
-                }
-            ],
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*"],
+                        "immutable": True
+                    }
+                ]
+            },
             "prompt_injection": {
                 "enabled": True,
                 "immutable": True
@@ -392,7 +428,7 @@ class ImmutableConfigTest(TestCase):
 
             # Should load successfully with immutable fields
             assert loaded_config is not None
-            assert loaded_config["permissions"][0]["immutable"] is True
+            assert loaded_config["permissions"]["rules"][0]["immutable"] is True
             assert loaded_config["prompt_injection"]["immutable"] is True
         finally:
             Path(temp_path).unlink()
@@ -400,14 +436,17 @@ class ImmutableConfigTest(TestCase):
     def test_invalid_immutable_type_rejected(self):
         """Invalid immutable field type is rejected by schema"""
         config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*"],
-                    "immutable": "yes"  # Invalid: should be boolean
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*"],
+                        "immutable": "yes"  # Invalid: should be boolean
+                    }
+                ]
+            }
         }
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -431,25 +470,31 @@ class ImmutableConfigTest(TestCase):
         """Enterprise can enforce skill allowlist that users cannot extend"""
         # Enterprise remote config
         enterprise_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["daf-*", "gh-cli"],
-                    "immutable": True
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["daf-*", "gh-cli"],
+                        "immutable": True
+                    }
+                ]
+            }
         }
 
         # User tries to add custom skill
         user_config = {
-            "permissions": [
-                {
-                    "matcher": "Skill",
-                    "mode": "allow",
-                    "patterns": ["my-custom-skill"]
-                }
-            ]
+            "permissions": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "matcher": "Skill",
+                        "mode": "allow",
+                        "patterns": ["my-custom-skill"]
+                    }
+                ]
+            }
         }
 
         # Create checker with both configs

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -91,7 +91,10 @@ def test_valid_config_validates(schema, valid_config):
 def test_minimal_valid_config(schema):
     """Test that a minimal valid configuration passes validation."""
     minimal_config = {
-        "permissions": []
+        "permissions": {
+            "enabled": True,
+            "rules": []
+        }
     }
 
     try:
@@ -115,13 +118,16 @@ def test_empty_config_is_valid(schema):
 def test_permission_rule_structure(schema):
     """Test that permission rules validate correctly."""
     config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "allow",
-                "patterns": ["daf-*", "gh-cli"]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": ["daf-*", "gh-cli"]
+                }
+            ]
+        }
     }
 
     try:
@@ -134,19 +140,22 @@ def test_permission_rule_structure(schema):
 def test_time_based_pattern(schema):
     """Test that time-based patterns validate correctly."""
     config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "allow",
-                "patterns": [
-                    "daf-*",
-                    {
-                        "pattern": "debug-*",
-                        "valid_until": "2026-04-13T12:00:00Z"
-                    }
-                ]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": [
+                        "daf-*",
+                        {
+                            "pattern": "debug-*",
+                            "valid_until": "2026-04-13T12:00:00Z"
+                        }
+                    ]
+                }
+            ]
+        }
     }
 
     try:
@@ -159,7 +168,7 @@ def test_time_based_pattern(schema):
 def test_time_based_feature_boolean(schema):
     """Test that boolean feature toggles validate correctly."""
     config = {
-        "permissions_enabled": {
+        "permissions": {
             "enabled": True
         },
         "secret_scanning": {
@@ -177,7 +186,7 @@ def test_time_based_feature_boolean(schema):
 def test_time_based_feature_extended(schema):
     """Test that extended time-based feature toggles validate correctly."""
     config = {
-        "permissions_enabled": {
+        "permissions": {
             "enabled": {
                 "value": False,
                 "disabled_until": "2026-04-13T18:00:00Z",
@@ -216,13 +225,16 @@ def test_prompt_injection_config(schema):
 def test_invalid_mode_rejected(schema):
     """Test that invalid permission mode is rejected."""
     config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "invalid_mode",
-                "patterns": ["daf-*"]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "invalid_mode",
+                    "patterns": ["daf-*"]
+                }
+            ]
+        }
     }
 
     with pytest.raises(ValidationError):
@@ -259,12 +271,15 @@ def test_invalid_sensitivity_rejected(schema):
 def test_missing_required_fields_rejected(schema):
     """Test that permission rules missing required fields are rejected."""
     config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                # missing mode and patterns
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    # missing mode and patterns
+                }
+            ]
+        }
     }
 
     with pytest.raises(ValidationError):
@@ -344,18 +359,21 @@ def test_pattern_server_config(schema):
 def test_time_based_bash_allow_pattern(schema):
     """Test that time-based Bash allow patterns validate correctly."""
     config = {
-        "permissions": [
-            {
-                "matcher": "Bash",
-                "mode": "allow",
-                "patterns": [
-                    {
-                        "pattern": "*docker rm*",
-                        "valid_until": "2026-04-13T15:00:00Z"
-                    }
-                ]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Bash",
+                    "mode": "allow",
+                    "patterns": [
+                        {
+                            "pattern": "*docker rm*",
+                            "valid_until": "2026-04-13T15:00:00Z"
+                        }
+                    ]
+                }
+            ]
+        }
     }
 
     try:
@@ -368,20 +386,23 @@ def test_time_based_bash_allow_pattern(schema):
 def test_mixed_simple_and_time_based_patterns(schema):
     """Test that mixed simple and time-based patterns validate correctly."""
     config = {
-        "permissions": [
-            {
-                "matcher": "Skill",
-                "mode": "allow",
-                "patterns": [
-                    "daf-*",
-                    "gh-cli",
-                    {
-                        "pattern": "debug-*",
-                        "valid_until": "2026-04-13T12:00:00Z"
-                    }
-                ]
-            }
-        ]
+        "permissions": {
+            "enabled": True,
+            "rules": [
+                {
+                    "matcher": "Skill",
+                    "mode": "allow",
+                    "patterns": [
+                        "daf-*",
+                        "gh-cli",
+                        {
+                            "pattern": "debug-*",
+                            "valid_until": "2026-04-13T12:00:00Z"
+                        }
+                    ]
+                }
+            ]
+        }
     }
 
     try:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

## Description
Refactored the configuration structure to unify permission-related settings under a single `permissions` object. Previously, `permissions_enabled` was a top-level field separate from the `permissions` configuration. This change moves `permissions_enabled` into the `permissions` object to improve configuration organization and consistency.

**Changes include:**
- Updated JSON schema to nest `permissions_enabled` within the `permissions` object
- Modified core configuration loading and validation logic in `tool_policy.py` and `__init__.py`
- Updated all TUI components (global settings, MCP servers, permissions, skills) to reference the new structure
- Updated example configurations and test fixtures
- Revised documentation (README.md, TUI.md) to reflect the new structure
- Updated all test cases to validate the new configuration format

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite to verify all tests pass: `pytest tests/`
3. Validate the JSON schema: `python -m ai_guardian.schemas.ai-guardian-config.schema`
4. Load the example config and verify it validates correctly
5. Launch the TUI and navigate through Global Settings, Permissions, MCP Servers, and Skills tabs to verify proper display and editing of the new config structure
6. Test both enabling and disabling permissions through the TUI to ensure the nested `permissions.permissions_enabled` field updates correctly

### Scenarios tested
- Configuration schema validation with the updated structure
- TUI rendering and editing of permission settings in the new nested format
- Loading and parsing of migrated configuration files
- All existing test suites passing with updated config structure

## Deployment considerations
- [x] This code change requires the following considerations before being deployed:
  - **Breaking change**: Existing configuration files using the old structure (`permissions_enabled` as a top-level field) will need to be migrated to the new structure (nested under `permissions` object)
  - Users should update their configs: move `"permissions_enabled": <value>` to be inside the `"permissions"` object
  - Consider providing a migration script or clear documentation for users to update their configurations