### PR TITLE
itdove/ai-guardian#113: Self-protection bypass: config edits allowed when validation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Issue #105 was filed as preventive security measure - vulnerability never existed
 
 ### Fixed
+- **Bug #113: Self-protection bypass when file_path parameter is missing**
+  - File-path tools (Edit, Write, Read, NotebookEdit) now fail-closed when file_path is missing
+  - Previously, malformed tool_input with missing file_path would bypass IMMUTABLE pattern checks
+  - AI could potentially bypass config/hooks protection by sending empty tool parameters
+  - Fixed by requiring file_path parameter for security checks on file-path tools
+  - Added comprehensive test coverage in `tests/test_self_protection.py`
+  - Affects: Edit, Write, Read, NotebookEdit tools with empty or malformed input
+
 - **Bug #102: Directory rules don't support combined wildcards (e.g., daf-*/**)**
   - Patterns combining single-level (`*`) and recursive (`**`) wildcards now work correctly
   - Example: `~/.claude/skills/daf-*/**` now matches all files under daf-git/, daf-jira/, etc.

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -384,6 +384,33 @@ class ToolPolicyChecker:
             # These protect ai-guardian config, IDE hooks, and pip-installed package code
             # EXCEPT: Development source code can be edited (fork + PR workflow)
             check_value = self._extract_check_value(tool_name, tool_input, tool_name)
+
+            # For file-path tools (Edit/Write/Read/NotebookEdit), require check_value
+            # If we can't extract file_path, fail-closed to prevent bypass (Issue #113)
+            is_file_path_tool = tool_name in ["Write", "Read", "Edit", "NotebookEdit"]
+            if is_file_path_tool and not check_value:
+                error_msg = (
+                    f"\n{'='*70}\n"
+                    f"🚨 BLOCKED BY POLICY\n"
+                    f"{'='*70}\n"
+                    f"Tool: {tool_name}\n"
+                    f"Reason: Missing required parameter (file_path)\n"
+                    f"\n"
+                    f"File-path tools require a file_path parameter for security checks.\n"
+                    f"This operation has been blocked to prevent bypassing immutable\n"
+                    f"file protections.\n"
+                    f"{'='*70}\n"
+                )
+                logger.error(f"🚨 BLOCKED: {tool_name} - missing file_path parameter")
+                self._log_violation(
+                    tool_name=tool_name,
+                    check_value="<missing file_path>",
+                    reason="missing required parameter",
+                    matcher=tool_name,
+                    hook_data=hook_data
+                )
+                return False, error_msg, tool_name
+
             if check_value:
                 # Check if this is development source code (allowed for contributors)
                 if self._should_skip_immutable_protection(check_value, tool_name):
@@ -840,6 +867,11 @@ class ToolPolicyChecker:
 
         # Edit: extract file_path from input
         if matcher == "Edit":
+            file_path = tool_input.get("file_path")
+            return file_path if file_path else None
+
+        # NotebookEdit: extract file_path from input
+        if matcher == "NotebookEdit":
             file_path = tool_input.get("file_path")
             return file_path if file_path else None
 

--- a/tests/test_self_protection.py
+++ b/tests/test_self_protection.py
@@ -1145,6 +1145,79 @@ class SelfProtectionTest(TestCase):
         self.assertFalse(is_allowed)
         self.assertNotIn("💡 TIP", error_msg)
 
+    # ========================================================================
+    # Test: Issue #113 - Fail-closed when file_path missing (prevent bypass)
+    # ========================================================================
+
+    def test_edit_blocks_when_file_path_missing_issue_113(self):
+        """
+        Issue #113: AI cannot bypass IMMUTABLE checks by sending malformed tool_input
+
+        BUG: If tool_input is empty or missing 'file_path', check_value becomes None
+        and IMMUTABLE pattern checks were skipped. This allowed bypassing protections.
+
+        FIX: For file-path tools, fail-closed (block) if file_path is missing.
+        """
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Edit",
+                "input": {}  # Missing file_path
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "Edit with missing file_path should be blocked")
+        self.assertIsNotNone(error_msg, "Error message should be provided")
+        self.assertIn("Missing required parameter", error_msg)
+        self.assertIn("file_path", error_msg)
+
+    def test_write_blocks_when_file_path_missing_issue_113(self):
+        """Write tool should block when file_path is missing (Issue #113)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Write",
+                # Missing "input" field entirely
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "Write with missing file_path should be blocked")
+        self.assertIn("Missing required parameter", error_msg)
+
+    def test_read_blocks_when_file_path_missing_issue_113(self):
+        """Read tool should block when file_path is missing (Issue #113)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Read",
+                "input": {"limit": 100}  # Has other params but missing file_path
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "Read with missing file_path should be blocked")
+        self.assertIn("Missing required parameter", error_msg)
+
+    def test_notebookedit_blocks_when_file_path_missing_issue_113(self):
+        """NotebookEdit tool should block when file_path is missing (Issue #113)"""
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "NotebookEdit",
+                "input": {}
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(is_allowed, "NotebookEdit with missing file_path should be blocked")
+        self.assertIn("Missing required parameter", error_msg)
+
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.
Related GitHub Issue: https://github.com/itdove/ai-guardian/issues/113

## Description
This PR fixes a critical security vulnerability in the self-protection mechanism where configuration file edits could bypass validation when the `file_path` parameter was missing from the tool call. The validation logic in `tool_policy.py` now properly handles cases where `file_path` is absent, ensuring that self-protection rules are consistently enforced.

**Changes:**
- Enhanced self-protection validation in `src/ai_guardian/tool_policy.py` to handle missing `file_path` parameters
- Added comprehensive test coverage in `tests/test_self_protection.py` to verify the fix
- Updated `CHANGELOG.md` to document the security fix

**Technical Decision:** The fix ensures that when validating tool calls against self-protection rules, the absence of a `file_path` parameter is treated as a validation failure rather than allowing the operation to proceed.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_self_protection.py -v`
3. Verify all self-protection tests pass, especially tests related to missing file_path parameters
4. Attempt to edit a protected configuration file without providing file_path parameter
5. Confirm that the operation is blocked by self-protection validation

### Scenarios tested
- Tool calls with missing `file_path` parameter against protected files are correctly blocked
- Tool calls with valid `file_path` parameter continue to work as expected
- Self-protection bypass attempts are prevented across different tool types

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed:

This is a security fix that strengthens existing protections without introducing breaking changes to the API or expected behavior.