### PR TITLE
itdove/ai-guardian#145: Show which protection blocked action and triggering pattern in error messages

### DIFF
--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -455,9 +455,10 @@ def _check_directory_rules(file_path, config):
         config: Configuration dict containing directory_rules
 
     Returns:
-        tuple: (decision, action) where:
+        tuple: (decision, action, matched_pattern) where:
             - decision: "allow", "deny", or None (no matching rule)
             - action: "block", "log", or None
+            - matched_pattern: The pattern that triggered the match, or None
     """
     try:
         if not config:
@@ -494,13 +495,14 @@ def _check_directory_rules(file_path, config):
 
         if not directory_rules:
             # No rules, but global_action still applies to .ai-read-deny markers
-            return None, global_action
+            return None, global_action, None
 
         # Convert file path to absolute path
         abs_file_path = os.path.abspath(os.path.expanduser(file_path))
 
         # Evaluate rules in order, last match wins
         final_decision = None
+        matched_pattern = None
 
         for rule in directory_rules:
             if not isinstance(rule, dict):
@@ -553,12 +555,14 @@ def _check_directory_rules(file_path, config):
 
                             if matched:
                                 final_decision = mode
+                                matched_pattern = pattern
                                 logging.debug(f"Path {abs_file_path} matched rule: {mode} {pattern} (action={global_action})")
                                 break
                         else:
                             # No wildcards in base_path, use simple startswith
                             if abs_file_path.startswith(base_path):
                                 final_decision = mode
+                                matched_pattern = pattern
                                 logging.debug(f"Path {abs_file_path} matched rule: {mode} {pattern} (action={global_action})")
                                 break
                     elif "*" in expanded_pattern:
@@ -566,12 +570,14 @@ def _check_directory_rules(file_path, config):
                         file_parent = os.path.dirname(abs_file_path)
                         if fnmatch.fnmatch(file_parent, expanded_pattern) or file_parent.startswith(expanded_pattern.replace("/*", "")):
                             final_decision = mode
+                            matched_pattern = pattern
                             logging.debug(f"Path {abs_file_path} matched rule: {mode} {pattern} (action={global_action})")
                             break
                     else:
                         # Exact path match
                         if abs_file_path.startswith(expanded_pattern + os.sep) or abs_file_path == expanded_pattern:
                             final_decision = mode
+                            matched_pattern = pattern
                             logging.debug(f"Path {abs_file_path} matched rule: {mode} {pattern} (action={global_action})")
                             break
 
@@ -579,14 +585,14 @@ def _check_directory_rules(file_path, config):
                     logging.warning(f"Error processing rule pattern '{pattern}': {e}")
                     continue
 
-        # Return decision and global action
+        # Return decision, global action, and matched pattern
         # Note: global_action is returned even when no rule matches because
         # it applies to ALL violations, including .ai-read-deny markers (issue #93)
-        return final_decision, global_action
+        return final_decision, global_action, matched_pattern
 
     except Exception as e:
         logging.error(f"Error checking directory rules: {e}")
-        return None
+        return None, None, None
 
 
 def check_directory_denied(file_path, config=None):
@@ -611,10 +617,11 @@ def check_directory_denied(file_path, config=None):
         config: Optional configuration dict containing directory_rules
 
     Returns:
-        tuple: (is_denied: bool, denied_directory: str or None, warning_message: str or None)
+        tuple: (is_denied: bool, denied_directory: str or None, warning_message: str or None, matched_pattern: str or None)
                - is_denied: True if access should be blocked
                - denied_directory: The directory containing .ai-read-deny, if found
                - warning_message: Warning message for log mode (when action="log")
+               - matched_pattern: The directory rule pattern that triggered the match, if any
     """
     try:
         # Load config if not provided
@@ -630,7 +637,7 @@ def check_directory_denied(file_path, config=None):
         abs_path = os.path.abspath(file_path)
 
         # PRIORITY 1: Check directory_rules
-        rule_decision, rule_action = _check_directory_rules(abs_path, config) if config else (None, None)
+        rule_decision, rule_action, matched_pattern = _check_directory_rules(abs_path, config) if config else (None, None, None)
 
         # PRIORITY 2: Check for .ai-read-deny marker files
         current_dir = os.path.dirname(abs_path)
@@ -660,7 +667,7 @@ def check_directory_denied(file_path, config=None):
             # Marker found - check if rules override it
             if rule_decision == "allow":
                 logging.info(f"Found .ai-read-deny at {denied_directory}, but directory rules allow access - allowing")
-                return False, None, None  # ALLOW - rule overrides marker
+                return False, None, None, matched_pattern  # ALLOW - rule overrides marker
             else:
                 # No allow rule to override - block or log
                 # Check if there's a deny rule with log action
@@ -668,12 +675,12 @@ def check_directory_denied(file_path, config=None):
                     logging.warning(f"Policy violation (log mode): {file_path} - .ai-read-deny marker in {denied_directory} but allowed for audit")
                     _log_directory_blocking_violation(file_path, denied_directory, is_excluded=False)
                     warn_msg = f"⚠️  Policy violation (log mode): Directory '{denied_directory}' denied by marker but allowed for audit"
-                    return False, None, warn_msg  # ALLOW - logged for audit, with warning
+                    return False, None, warn_msg, matched_pattern  # ALLOW - logged for audit, with warning
                 else:
                     # Block access
                     logging.error(f".ai-read-deny marker blocks access to {denied_directory}")
                     _log_directory_blocking_violation(file_path, denied_directory, is_excluded=False)
-                    return True, denied_directory, None  # BLOCK
+                    return True, denied_directory, None, matched_pattern  # BLOCK
 
         # No .ai-read-deny marker - check rule decision
         if rule_decision == "deny":
@@ -682,20 +689,20 @@ def check_directory_denied(file_path, config=None):
                 logging.warning(f"Policy violation (log mode): {file_path} - denied by rules but allowed for audit")
                 _log_directory_blocking_violation(file_path, os.path.dirname(abs_path), is_excluded=False)
                 warn_msg = f"⚠️  Policy violation (log mode): Directory rules deny '{file_path}' but allowed for audit"
-                return False, None, warn_msg  # ALLOW - logged for audit, with warning
+                return False, None, warn_msg, matched_pattern  # ALLOW - logged for audit, with warning
             else:
                 # Block access
                 logging.error(f"Directory rules deny access to {abs_path}")
                 _log_directory_blocking_violation(file_path, os.path.dirname(abs_path), is_excluded=False)
-                return True, os.path.dirname(abs_path), None  # BLOCK
+                return True, os.path.dirname(abs_path), None, matched_pattern  # BLOCK
 
         # Default: allow access
-        return False, None, None
+        return False, None, None, None
 
     except Exception as e:
         logging.error(f"Error checking directory access: {e}")
         # Fail-open: allow access if check fails
-        return False, None, None
+        return False, None, None, None
 
 
 def extract_tool_result(hook_data):
@@ -798,24 +805,39 @@ def extract_file_content_from_tool(hook_data):
             file_path = hook_data["file_path"]
 
             # Check if directory is denied
-            is_denied, denied_dir, dir_warning = check_directory_denied(file_path)
+            is_denied, denied_dir, dir_warning, matched_pattern = check_directory_denied(file_path)
             if is_denied:
                 error_msg = (
                     f"\n{'='*70}\n"
                     f"🚨 BLOCKED BY POLICY\n"
-                    f"🚫 ACCESS DENIED - Directory Protected\n"
+                    f"🚫 DIRECTORY ACCESS DENIED\n"
                     f"{'='*70}\n\n"
-                    f"The file '{file_path}' is located in a directory that contains\n"
-                    f"a .ai-read-deny marker file.\n\n"
-                    f"Protected directory: {denied_dir}\n\n"
-                    f"This directory and all its subdirectories are blocked from AI access.\n\n"
-                    f"DO NOT attempt workarounds - the protection is intentional.\n\n"
-                    f"To allow access:\n"
-                    f"  1. Remove the .ai-read-deny file from {denied_dir}\n"
-                    f"  2. Move this file to an accessible location\n"
-                    f"  3. Add this path to directory_exclusions in ai-guardian.json\n"
-                    f"\n{'='*70}\n"
+                    f"File: {file_path}\n"
                 )
+                if denied_dir:
+                    error_msg += f"Protected Directory: {denied_dir}\n"
+                if matched_pattern:
+                    error_msg += f"Triggered Pattern: {matched_pattern}\n"
+                    error_msg += f"\nProtection Type: Directory rule\n\n"
+                    error_msg += (
+                        f"This file is blocked by a directory access rule.\n\n"
+                        f"DO NOT attempt workarounds - the protection is intentional.\n\n"
+                        f"To allow access:\n"
+                        f"  1. Update directory_rules in ai-guardian.json\n"
+                        f"  2. Move this file to an accessible location\n"
+                    )
+                else:
+                    error_msg += f"\nProtection Type: .ai-read-deny marker\n\n"
+                    error_msg += (
+                        f"This directory contains a .ai-read-deny marker file.\n"
+                        f"All subdirectories are blocked from AI access.\n\n"
+                        f"DO NOT attempt workarounds - the protection is intentional.\n\n"
+                        f"To allow access:\n"
+                        f"  1. Remove the .ai-read-deny file from {denied_dir}\n"
+                        f"  2. Move this file to an accessible location\n"
+                        f"  3. Add an allow rule in directory_rules config\n"
+                    )
+                error_msg += f"\n{'='*70}\n"
                 return None, os.path.basename(file_path), file_path, True, error_msg, None
 
             return content, os.path.basename(file_path), file_path, False, None, dir_warning
@@ -865,24 +887,39 @@ def extract_file_content_from_tool(hook_data):
         file_path = os.path.expanduser(file_path)
 
         # Check if directory is denied BEFORE reading the file
-        is_denied, denied_dir, dir_warning = check_directory_denied(file_path)
+        is_denied, denied_dir, dir_warning, matched_pattern = check_directory_denied(file_path)
         if is_denied:
             error_msg = (
                 f"\n{'='*70}\n"
                 f"🚨 BLOCKED BY POLICY\n"
-                f"🚫 ACCESS DENIED - Directory Protected\n"
+                f"🚫 DIRECTORY ACCESS DENIED\n"
                 f"{'='*70}\n\n"
-                f"The file '{file_path}' is located in a directory that contains\n"
-                f"a .ai-read-deny marker file.\n\n"
-                f"Protected directory: {denied_dir}\n\n"
-                f"This directory and all its subdirectories are blocked from AI access.\n\n"
-                f"DO NOT attempt workarounds - the protection is intentional.\n\n"
-                f"To allow access:\n"
-                f"  1. Remove the .ai-read-deny file from {denied_dir}\n"
-                f"  2. Move this file to an accessible location\n"
-                f"  3. Add this path to directory_exclusions in ai-guardian.json\n"
-                f"\n{'='*70}\n"
+                f"File: {file_path}\n"
             )
+            if denied_dir:
+                error_msg += f"Protected Directory: {denied_dir}\n"
+            if matched_pattern:
+                error_msg += f"Triggered Pattern: {matched_pattern}\n"
+                error_msg += f"\nProtection Type: Directory rule\n\n"
+                error_msg += (
+                    f"This file is blocked by a directory access rule.\n\n"
+                    f"DO NOT attempt workarounds - the protection is intentional.\n\n"
+                    f"To allow access:\n"
+                    f"  1. Update directory_rules in ai-guardian.json\n"
+                    f"  2. Move this file to an accessible location\n"
+                )
+            else:
+                error_msg += f"\nProtection Type: .ai-read-deny marker\n\n"
+                error_msg += (
+                    f"This directory contains a .ai-read-deny marker file.\n"
+                    f"All subdirectories are blocked from AI access.\n\n"
+                    f"DO NOT attempt workarounds - the protection is intentional.\n\n"
+                    f"To allow access:\n"
+                    f"  1. Remove the .ai-read-deny file from {denied_dir}\n"
+                    f"  2. Move this file to an accessible location\n"
+                    f"  3. Add an allow rule in directory_rules config\n"
+                )
+            error_msg += f"\n{'='*70}\n"
             return None, os.path.basename(file_path), file_path, True, error_msg, None
 
         # Read the file content

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -429,7 +429,7 @@ class ToolPolicyChecker:
                         matches = fnmatch.fnmatch(check_value, pattern)
 
                     if matches:
-                        error_msg = self._format_immutable_deny_message(check_value, tool_name)
+                        error_msg = self._format_immutable_deny_message(check_value, tool_name, pattern)
                         self._log_violation(
                             tool_name=tool_name,
                             check_value=check_value,
@@ -974,13 +974,14 @@ class ToolPolicyChecker:
         return msg
 
 
-    def _format_immutable_deny_message(self, check_value: str, tool_name: str) -> str:
+    def _format_immutable_deny_message(self, check_value: str, tool_name: str, matched_pattern: str = None) -> str:
         """
         Format error message for immutable deny (cannot be overridden).
 
         Args:
             check_value: The value that was blocked (file path, command, etc.)
             tool_name: The tool that was blocked
+            matched_pattern: The specific immutable pattern that triggered the block
 
         Returns:
             str: Formatted error message
@@ -1055,6 +1056,8 @@ class ToolPolicyChecker:
                 f"{value_label}: {check_value}\n"
                 f"Tool: {tool_name}\n"
             )
+            if matched_pattern:
+                base_message += f"Triggered Pattern: {matched_pattern}\n"
         else:
             base_message = (
                 f"\n{'='*70}\n"
@@ -1065,13 +1068,15 @@ class ToolPolicyChecker:
                 f"{value_label}: {check_value}\n"
                 f"Tool: {tool_name}\n"
             )
+            if matched_pattern:
+                base_message += f"Triggered Pattern: {matched_pattern}\n"
 
         # Add diagnostic information for source files
         # Note: This should only be reached for pip-installed code (site-packages),
         # since development repo source files are allowed via _should_skip_immutable_protection
         if is_source_file:
             return base_message + (
-                f"\nReason: Pip-installed package source code (production deployment)\n\n"
+                f"\nProtection Type: Pip-installed package source code (production deployment)\n\n"
                 f"This file is part of the pip-installed ai-guardian package and cannot\n"
                 f"be modified to prevent bypassing security controls in production.\n\n"
                 f"If you're developing ai-guardian:\n"
@@ -1099,7 +1104,7 @@ class ToolPolicyChecker:
 
         if is_marker_file:
             return base_message + tip_message + (
-                f"\nReason: Directory protection marker\n\n"
+                f"\nProtection Type: Directory protection marker\n\n"
                 f"Protected files:\n"
                 f"  • ai-guardian configuration files\n"
                 f"  • IDE hook configuration (Claude, Cursor)\n"
@@ -1113,7 +1118,7 @@ class ToolPolicyChecker:
             )
         else:
             return base_message + tip_message + (
-                f"\nReason: Critical security configuration\n\n"
+                f"\nProtection Type: Immutable file protection\n\n"
                 f"Protected files:\n"
                 f"  • ai-guardian configuration files\n"
                 f"  • IDE hook configuration (Claude, Cursor)\n"

--- a/tests/test_combined_wildcards.py
+++ b/tests/test_combined_wildcards.py
@@ -31,22 +31,22 @@ class CombinedWildcardsTest(unittest.TestCase):
 
         # Should match daf-git skill
         daf_git_file = os.path.join(skills_dir, "daf-git", "SKILL.md")
-        is_denied, _, _ = check_directory_denied(daf_git_file, config)
+        is_denied, _, _, _ = check_directory_denied(daf_git_file, config)
         self.assertFalse(is_denied, f"daf-*/** pattern should match {daf_git_file}")
 
         # Should match daf-jira skill
         daf_jira_file = os.path.join(skills_dir, "daf-jira", "config.json")
-        is_denied, _, _ = check_directory_denied(daf_jira_file, config)
+        is_denied, _, _, _ = check_directory_denied(daf_jira_file, config)
         self.assertFalse(is_denied, f"daf-*/** pattern should match {daf_jira_file}")
 
         # Should match nested files
         daf_nested = os.path.join(skills_dir, "daf-config", "subdir", "file.txt")
-        is_denied, _, _ = check_directory_denied(daf_nested, config)
+        is_denied, _, _, _ = check_directory_denied(daf_nested, config)
         self.assertFalse(is_denied, f"daf-*/** pattern should match nested files")
 
         # Should NOT match non-daf skills
         other_skill = os.path.join(skills_dir, "code-review", "SKILL.md")
-        is_denied, _, _ = check_directory_denied(other_skill, config)
+        is_denied, _, _, _ = check_directory_denied(other_skill, config)
         self.assertTrue(is_denied, "daf-*/** pattern should NOT match non-daf skills")
 
     def test_multiple_wildcards_in_path(self):
@@ -65,16 +65,16 @@ class CombinedWildcardsTest(unittest.TestCase):
 
         # Should match different projects' src directories
         project1_file = os.path.join(projects_dir, "myapp", "src", "main.py")
-        is_denied, _, _ = check_directory_denied(project1_file, config)
+        is_denied, _, _, _ = check_directory_denied(project1_file, config)
         self.assertFalse(is_denied, f"*/src/** should match {project1_file}")
 
         project2_file = os.path.join(projects_dir, "backend", "src", "api", "handler.go")
-        is_denied, _, _ = check_directory_denied(project2_file, config)
+        is_denied, _, _, _ = check_directory_denied(project2_file, config)
         self.assertFalse(is_denied, f"*/src/** should match {project2_file}")
 
         # Should NOT match non-src directories
         tests_file = os.path.join(projects_dir, "myapp", "tests", "test.py")
-        is_denied, _, _ = check_directory_denied(tests_file, config)
+        is_denied, _, _, _ = check_directory_denied(tests_file, config)
         self.assertTrue(is_denied, "*/src/** should NOT match tests directory")
 
     def test_real_world_skill_allowlist(self):
@@ -103,7 +103,7 @@ class CombinedWildcardsTest(unittest.TestCase):
 
         for skill_path in daf_skills:
             full_path = os.path.join(skills_dir, skill_path)
-            is_denied, _, _ = check_directory_denied(full_path, config)
+            is_denied, _, _, _ = check_directory_denied(full_path, config)
             self.assertFalse(is_denied, f"daf-*/** should allow {skill_path}")
 
         # Non-daf skills should be denied
@@ -115,7 +115,7 @@ class CombinedWildcardsTest(unittest.TestCase):
 
         for skill_path in non_daf_skills:
             full_path = os.path.join(skills_dir, skill_path)
-            is_denied, _, _ = check_directory_denied(full_path, config)
+            is_denied, _, _, _ = check_directory_denied(full_path, config)
             self.assertTrue(is_denied, f"daf-*/** should NOT allow {skill_path}")
 
     def test_tilde_with_combined_wildcards(self):
@@ -131,12 +131,12 @@ class CombinedWildcardsTest(unittest.TestCase):
 
         # Should allow daf-* skills
         test_file = os.path.join(home, ".claude", "skills", "daf-git", "SKILL.md")
-        is_denied, _, _ = check_directory_denied(test_file, config)
+        is_denied, _, _, _ = check_directory_denied(test_file, config)
         self.assertFalse(is_denied, "Tilde should expand correctly with combined wildcards")
 
         # Should deny non-daf skills
         other_file = os.path.join(home, ".claude", "skills", "other-skill", "file.md")
-        is_denied, _, _ = check_directory_denied(other_file, config)
+        is_denied, _, _, _ = check_directory_denied(other_file, config)
         self.assertTrue(is_denied, "Non-daf skills should be denied")
 
 

--- a/tests/test_directory_blocking.py
+++ b/tests/test_directory_blocking.py
@@ -67,7 +67,7 @@ def test_directory_blocking():
         }
 
         # Test 1: Allowed file should not be blocked
-        is_denied, denied_path, _ = check_directory_denied(allowed_file, test_config)
+        is_denied, denied_path, _, _ = check_directory_denied(allowed_file, test_config)
         assert not is_denied, f"FAIL: Allowed file was blocked"
         assert denied_path is None, f"FAIL: Allowed file has denied path"
         print(f"✓ Test 1 PASSED: Allowed file is accessible")
@@ -75,7 +75,7 @@ def test_directory_blocking():
         print(f"  Blocked: {is_denied}")
 
         # Test 2: File in denied directory should be blocked
-        is_denied, denied_path, _ = check_directory_denied(blocked_file, test_config)
+        is_denied, denied_path, _, _ = check_directory_denied(blocked_file, test_config)
         assert is_denied, f"FAIL: Denied file was not blocked"
         assert denied_path == denied_dir, f"FAIL: Wrong denied directory reported"
         print(f"✓ Test 2 PASSED: File in denied directory is blocked")
@@ -84,7 +84,7 @@ def test_directory_blocking():
         print(f"  Denied dir: {denied_path}")
 
         # Test 3: File in subdirectory of denied directory should be blocked
-        is_denied, denied_path, _ = check_directory_denied(deeply_blocked_file, test_config)
+        is_denied, denied_path, _, _ = check_directory_denied(deeply_blocked_file, test_config)
         assert is_denied, f"FAIL: Nested file in denied directory was not blocked"
         assert denied_path == denied_dir, f"FAIL: Wrong denied directory reported for nested file"
         print(f"✓ Test 3 PASSED: Nested file in denied directory is blocked")

--- a/tests/test_directory_exclusions.py
+++ b/tests/test_directory_exclusions.py
@@ -36,7 +36,7 @@ def test_basic_exclusion():
             }
         }
 
-        is_denied, denied_dir, _ = check_directory_denied(allowed_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(allowed_file, config)
         assert not is_denied, "Excluded directory should allow access"
         assert denied_dir is None, "Should not have denied directory"
         print("✓ Test 1 PASSED: Basic exclusion works (no .ai-read-deny)")
@@ -71,7 +71,7 @@ def test_ai_read_deny_overrides_exclusion():
             }
         }
 
-        is_denied, denied_dir, _ = check_directory_denied(blocked_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(blocked_file, config)
         # NEW BEHAVIOR (v1.6.0): directory_exclusions (converted to allow rules) CAN override .ai-read-deny
         assert not is_denied, "directory_exclusions (allow rules) should override .ai-read-deny"
         print("✓ Test 2 PASSED: directory_exclusions overrides .ai-read-deny (NEW in v1.6.0)")
@@ -113,12 +113,12 @@ def test_subdirectory_deny_in_excluded_parent():
         }
 
         # Public file should be allowed (in excluded dir, no .ai-read-deny)
-        is_denied, denied_dir, _ = check_directory_denied(allowed_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(allowed_file, config)
         assert not is_denied, "File in excluded dir should be allowed"
 
         # Secret file should be allowed (parent exclusion overrides subdirectory .ai-read-deny)
         # NEW BEHAVIOR (v1.6.0): exclusions apply recursively and override .ai-read-deny
-        is_denied, denied_dir, _ = check_directory_denied(blocked_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(blocked_file, config)
         assert not is_denied, "Parent exclusion should override subdirectory .ai-read-deny"
 
         print("✓ Test 3 PASSED: Parent exclusion overrides subdirectory .ai-read-deny (NEW in v1.6.0)")
@@ -146,7 +146,7 @@ def test_tilde_expansion():
             }
         }
 
-        is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
         assert not is_denied, "Tilde expansion should work"
         print("✓ Test 4 PASSED: Tilde expansion works")
 
@@ -175,7 +175,7 @@ def test_wildcard_matching():
             }
         }
 
-        is_denied, denied_dir, _ = check_directory_denied(deep_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(deep_file, config)
         assert not is_denied, "** should match recursively"
         print("✓ Test 5 PASSED: Wildcard ** matches recursively")
 
@@ -201,7 +201,7 @@ def test_exclusion_disabled():
         }
 
         # Should not exclude (disabled)
-        is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
         assert not is_denied, "Should allow (no .ai-read-deny, exclusions disabled)"
         print("✓ Test 6 PASSED: Disabled exclusions don't apply")
 
@@ -223,7 +223,7 @@ def test_missing_exclusion_config():
             "permissions": []
         }
 
-        is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
         assert not is_denied, "Should allow (no .ai-read-deny, no exclusions)"
         print("✓ Test 7 PASSED: Backward compatible (missing config)")
 
@@ -254,7 +254,7 @@ def test_invalid_paths():
         }
 
         # Should handle invalid paths gracefully and still apply valid ones
-        is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
         assert not is_denied, "Should apply valid path despite invalid ones"
         print("✓ Test 8 PASSED: Invalid paths handled gracefully (fail-safe)")
 
@@ -279,7 +279,7 @@ def test_absolute_paths():
             }
         }
 
-        is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+        is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
         assert not is_denied, "Absolute path should work"
         print("✓ Test 9 PASSED: Absolute paths work")
 
@@ -297,7 +297,7 @@ def test_no_config():
             f.write("test content")
 
         # No config
-        is_denied, denied_dir, _ = check_directory_denied(test_file, None)
+        is_denied, denied_dir, _, _ = check_directory_denied(test_file, None)
         assert not is_denied, "Should allow (no .ai-read-deny, no config)"
         print("✓ Test 10 PASSED: None config handled correctly")
 

--- a/tests/test_directory_rules.py
+++ b/tests/test_directory_rules.py
@@ -29,11 +29,11 @@ class DirectoryRulesOrderTest(unittest.TestCase):
         }
 
         # Denied by first rule
-        is_denied, _, _ = check_directory_denied("/tmp/skills/blocked/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/skills/blocked/file.txt", config)
         self.assertTrue(is_denied, "Should be denied by first rule")
 
         # Allowed by second rule (overrides first)
-        is_denied, _, _ = check_directory_denied("/tmp/skills/approved/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/skills/approved/file.txt", config)
         self.assertFalse(is_denied, "Should be allowed by second rule")
 
     def test_last_rule_wins_allow_then_deny(self):
@@ -46,11 +46,11 @@ class DirectoryRulesOrderTest(unittest.TestCase):
         }
 
         # Allowed by first rule
-        is_denied, _, _ = check_directory_denied("/tmp/projects/public/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/projects/public/file.txt", config)
         self.assertFalse(is_denied, "Should be allowed by first rule")
 
         # Denied by second rule (overrides first)
-        is_denied, _, _ = check_directory_denied("/tmp/projects/secret/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/projects/secret/file.txt", config)
         self.assertTrue(is_denied, "Should be denied by second rule")
 
     def test_multiple_rules_last_match_wins(self):
@@ -64,15 +64,15 @@ class DirectoryRulesOrderTest(unittest.TestCase):
         }
 
         # Denied by first rule
-        is_denied, _, _ = check_directory_denied("/tmp/blocked/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/blocked/file.txt", config)
         self.assertTrue(is_denied)
 
         # Allowed by second rule
-        is_denied, _, _ = check_directory_denied("/tmp/allow/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/allow/file.txt", config)
         self.assertFalse(is_denied)
 
         # Denied by third rule (overrides second)
-        is_denied, _, _ = check_directory_denied("/tmp/allow/deny-again/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/allow/deny-again/file.txt", config)
         self.assertTrue(is_denied)
 
 
@@ -91,7 +91,7 @@ class DirectoryRulesWithMarkersTest(unittest.TestCase):
             test_file.touch()
 
             # Without rule: should be denied
-            is_denied, _, _ = check_directory_denied(str(test_file), {})
+            is_denied, _, _, _ = check_directory_denied(str(test_file), {})
             self.assertTrue(is_denied, "Should be denied by .ai-read-deny marker")
 
             # With allow rule: should be allowed (rule overrides marker)
@@ -100,7 +100,7 @@ class DirectoryRulesWithMarkersTest(unittest.TestCase):
                     {"mode": "allow", "paths": [tmpdir]}
                 ]
             }
-            is_denied, _, _ = check_directory_denied(str(test_file), config)
+            is_denied, _, _, _ = check_directory_denied(str(test_file), config)
             self.assertFalse(is_denied, "Allow rule should override .ai-read-deny marker")
 
     def test_deny_marker_without_allow_rule(self):
@@ -117,7 +117,7 @@ class DirectoryRulesWithMarkersTest(unittest.TestCase):
                 ]
             }
 
-            is_denied, _, _ = check_directory_denied(str(test_file), config)
+            is_denied, _, _, _ = check_directory_denied(str(test_file), config)
             self.assertTrue(is_denied, ".ai-read-deny should block when no allow rule matches")
 
     def test_deny_rule_without_marker(self):
@@ -133,7 +133,7 @@ class DirectoryRulesWithMarkersTest(unittest.TestCase):
                 ]
             }
 
-            is_denied, _, _ = check_directory_denied(str(test_file), config)
+            is_denied, _, _, _ = check_directory_denied(str(test_file), config)
             self.assertTrue(is_denied, "Deny rule should block even without marker")
 
 
@@ -149,17 +149,17 @@ class DirectoryRulesWildcardsTest(unittest.TestCase):
         }
 
         # Should match at any depth
-        is_denied, _, _ = check_directory_denied("/tmp/skills/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/skills/file.txt", config)
         self.assertTrue(is_denied)
 
-        is_denied, _, _ = check_directory_denied("/tmp/skills/sub/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/skills/sub/file.txt", config)
         self.assertTrue(is_denied)
 
-        is_denied, _, _ = check_directory_denied("/tmp/skills/sub/deep/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/skills/sub/deep/file.txt", config)
         self.assertTrue(is_denied)
 
         # Should not match outside directory
-        is_denied, _, _ = check_directory_denied("/tmp/other/file.txt", config)
+        is_denied, _, _, _ = check_directory_denied("/tmp/other/file.txt", config)
         self.assertFalse(is_denied)
 
     def test_tilde_expansion(self):
@@ -173,7 +173,7 @@ class DirectoryRulesWildcardsTest(unittest.TestCase):
 
         # Should expand ~ and match
         test_path = os.path.join(home, ".claude", "skills", "test.txt")
-        is_denied, _, _ = check_directory_denied(test_path, config)
+        is_denied, _, _, _ = check_directory_denied(test_path, config)
         self.assertTrue(is_denied, "~ should expand to home directory")
 
 
@@ -196,7 +196,7 @@ class BackwardCompatibilityTest(unittest.TestCase):
                 }
             }
 
-            is_denied, _, _ = check_directory_denied(str(test_file), config)
+            is_denied, _, _, _ = check_directory_denied(str(test_file), config)
             self.assertFalse(is_denied, "directory_exclusions should work as allow rules")
 
     def test_exclusions_have_lower_priority_than_explicit_rules(self):
@@ -216,7 +216,7 @@ class BackwardCompatibilityTest(unittest.TestCase):
                 ]
             }
 
-            is_denied, _, _ = check_directory_denied(str(test_file), config)
+            is_denied, _, _, _ = check_directory_denied(str(test_file), config)
             self.assertTrue(is_denied, "Explicit deny rule should override backward compat allow")
 
 
@@ -243,12 +243,12 @@ class SkillAllowlistExampleTest(unittest.TestCase):
 
         # Approved skill: allowed
         approved = os.path.join(skills_dir, "bugfix-workflow", "SKILL.md")
-        is_denied, _, _ = check_directory_denied(approved, config)
+        is_denied, _, _, _ = check_directory_denied(approved, config)
         self.assertFalse(is_denied, "Approved skill should be allowed")
 
         # Unapproved skill: denied
         unapproved = os.path.join(skills_dir, "database-migration", "SKILL.md")
-        is_denied, _, _ = check_directory_denied(unapproved, config)
+        is_denied, _, _, _ = check_directory_denied(unapproved, config)
         self.assertTrue(is_denied, "Unapproved skill should be denied")
 
 

--- a/tests/test_directory_rules_log_mode_bug.py
+++ b/tests/test_directory_rules_log_mode_bug.py
@@ -45,7 +45,7 @@ class DirectoryRulesLogModeBugTest(unittest.TestCase):
                 }
             }
 
-            is_denied, denied_dir, warn_msg = check_directory_denied(test_file, config)
+            is_denied, denied_dir, warn_msg, _ = check_directory_denied(test_file, config)
 
             # Should be allowed with warning (bug: currently blocks)
             self.assertFalse(is_denied, "Log mode should allow access even with .ai-read-deny marker")
@@ -74,7 +74,7 @@ class DirectoryRulesLogModeBugTest(unittest.TestCase):
                 }
             }
 
-            is_denied, denied_dir, warn_msg = check_directory_denied(test_file, config)
+            is_denied, denied_dir, warn_msg, _ = check_directory_denied(test_file, config)
 
             # Should be allowed with warning
             self.assertFalse(is_denied, "Log mode should allow access")
@@ -101,7 +101,7 @@ class DirectoryRulesLogModeBugTest(unittest.TestCase):
                 }
             }
 
-            is_denied, denied_dir, warn_msg = check_directory_denied(test_file, config)
+            is_denied, denied_dir, warn_msg, _ = check_directory_denied(test_file, config)
 
             # Should be blocked
             self.assertTrue(is_denied, "Block mode should deny access with .ai-read-deny marker")

--- a/tests/test_enforcement_levels.py
+++ b/tests/test_enforcement_levels.py
@@ -214,7 +214,7 @@ class DirectoryRulesEnforcementTest(unittest.TestCase):
                 }
             }
 
-            is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+            is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
 
             # Should be allowed in log mode
             self.assertFalse(is_denied, "Log mode should allow access")
@@ -239,7 +239,7 @@ class DirectoryRulesEnforcementTest(unittest.TestCase):
                 }
             }
 
-            is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+            is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
 
             # Should be blocked
             self.assertTrue(is_denied, "Block mode should deny access")
@@ -267,7 +267,7 @@ class DirectoryRulesEnforcementTest(unittest.TestCase):
                 }
             }
 
-            is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+            is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
 
             # Should be allowed with warning
             self.assertFalse(is_denied, "Log mode should allow even with marker")
@@ -319,7 +319,7 @@ class ActionDefaultsTest(unittest.TestCase):
                 ]
             }
 
-            is_denied, denied_dir, _ = check_directory_denied(test_file, config)
+            is_denied, denied_dir, _, _ = check_directory_denied(test_file, config)
 
             # Should be blocked (default)
             self.assertTrue(is_denied)

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -270,6 +270,140 @@ class PromptInjectionErrorMessageTest(TestCase):
                     self.assertTrue(True, "Pattern was truncated with ellipsis")
 
 
+class ImmutablePatternErrorMessageTest(TestCase):
+    """Test suite for immutable pattern error messages (Issue #145)"""
+
+    def test_immutable_pattern_shows_triggered_pattern(self):
+        """Immutable pattern error should show which pattern was triggered"""
+        config = {
+            "permissions": []
+        }
+
+        policy_checker = ToolPolicyChecker(config=config)
+
+        # Try to edit a protected file (.claude/settings.json)
+        hook_data = {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/home/user/.claude/settings.json"}
+        }
+
+        allowed, error_msg, _ = policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(allowed, "Editing .claude/settings.json should be blocked")
+        self.assertIsNotNone(error_msg, "Should have error message")
+
+        # Verify error message contains the triggered pattern
+        self.assertIn("Triggered Pattern:", error_msg,
+                     "Error message should show the triggered pattern")
+        self.assertIn(".claude/settings.json", error_msg,
+                     "Error message should contain the pattern that matched")
+        self.assertIn("Protection Type:", error_msg,
+                     "Error message should show protection type")
+
+    def test_immutable_bash_command_shows_triggered_pattern(self):
+        """Immutable bash command error should show which pattern was triggered"""
+        config = {
+            "permissions": []
+        }
+
+        policy_checker = ToolPolicyChecker(config=config)
+
+        # Try to run a bash command that modifies ai-guardian
+        hook_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm ~/.config/ai-guardian/ai-guardian.json"}
+        }
+
+        allowed, error_msg, _ = policy_checker.check_tool_allowed(hook_data)
+
+        self.assertFalse(allowed, "Removing ai-guardian.json should be blocked")
+        self.assertIsNotNone(error_msg, "Should have error message")
+
+        # Verify error message contains the triggered pattern
+        self.assertIn("Triggered Pattern:", error_msg,
+                     "Error message should show the triggered pattern")
+        self.assertIn("Protection Type:", error_msg,
+                     "Error message should show protection type")
+        self.assertIn("CRITICAL COMMAND BLOCKED", error_msg,
+                     "Error message should show command blocked header")
+
+
+class DirectoryRuleErrorMessageTest(TestCase):
+    """Test suite for directory rule error messages (Issue #145)"""
+
+    def test_directory_rule_shows_triggered_pattern(self):
+        """Directory rule error should show which pattern was triggered"""
+        import ai_guardian
+        import tempfile
+        import os
+
+        # Create a temporary directory and file
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test.txt")
+            with open(test_file, 'w') as f:
+                f.write("test content")
+
+            # Create config with directory rule denying the temp directory
+            config = {
+                "directory_rules": {
+                    "action": "block",
+                    "rules": [
+                        {
+                            "mode": "deny",
+                            "paths": [f"{tmpdir}/**"]
+                        }
+                    ]
+                }
+            }
+
+            # Check if directory is denied
+            is_denied, denied_dir, warning, matched_pattern = ai_guardian.check_directory_denied(
+                test_file, config
+            )
+
+            self.assertTrue(is_denied, "File in denied directory should be blocked")
+            self.assertIsNotNone(matched_pattern, "Should have matched pattern")
+            self.assertIn(tmpdir, matched_pattern,
+                         "Matched pattern should contain the directory path")
+            self.assertIn("**", matched_pattern,
+                         "Matched pattern should show the wildcard pattern")
+
+    def test_directory_marker_shows_protection_type(self):
+        """Directory marker error should show protection type clearly"""
+        import ai_guardian
+        import tempfile
+        import os
+
+        # Create a temporary directory with .ai-read-deny marker
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create .ai-read-deny marker
+            marker_file = os.path.join(tmpdir, ".ai-read-deny")
+            with open(marker_file, 'w') as f:
+                f.write("")
+
+            test_file = os.path.join(tmpdir, "test.txt")
+            with open(test_file, 'w') as f:
+                f.write("test content")
+
+            # Create config with block action (default)
+            config = {
+                "directory_rules": {
+                    "action": "block",
+                    "rules": []
+                }
+            }
+
+            # Check if directory is denied
+            is_denied, denied_dir, warning, matched_pattern = ai_guardian.check_directory_denied(
+                test_file, config=config
+            )
+
+            self.assertTrue(is_denied, "File with .ai-read-deny marker should be blocked")
+            self.assertEqual(denied_dir, tmpdir, "Should identify the directory with marker")
+            # matched_pattern should be None for marker-based blocks (not rule-based)
+            self.assertIsNone(matched_pattern, "Marker-based blocks don't have a rule pattern")
+
+
 class ErrorMessageReadabilityTest(TestCase):
     """Test that enhanced error messages remain readable and well-formatted"""
 


### PR DESCRIPTION
Jira Issue: <https://redhat.atlassian.net//browse/itdove/ai-guardian#145>

## Description
This PR enhances error messages in the AI Guardian tool policy system to show which specific protection rule blocked an action and what pattern triggered the block. Previously, when a directory access rule was violated, the error message only indicated that access was blocked without providing details about which rule or pattern caused the rejection.

The changes track matched patterns in directory rule checks and propagate this information through the policy evaluation stack. When a violation occurs, users now receive detailed feedback including:
- The specific protection rule that blocked the action
- The exact pattern that was matched
- The requested path that triggered the violation

This improves the developer experience by making it easier to understand why an action was blocked and how to adjust either the request or the policy rules accordingly.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Set up a test policy configuration with directory rules (e.g., block access to `/etc/*` or sensitive directories)
3. Attempt to access a blocked directory path through the AI Guardian tool policy
4. Verify that the error message includes:
   - The name of the protection rule that was triggered
   - The specific pattern that matched (e.g., `/etc/*`)
   - Clear indication of what was blocked
5. Test with various pattern types (wildcards, exclusions, combined rules)
6. Confirm that legitimate access (non-blocked paths) still works normally

### Scenarios tested
- Directory blocking with wildcard patterns (`test_directory_blocking.py`)
- Directory exclusion rules (`test_directory_exclusions.py`)
- Combined wildcard scenarios (`test_combined_wildcards.py`)
- General directory rule enforcement (`test_directory_rules.py`)
- Directory rules in log mode (`test_directory_rules_log_mode_bug.py`)
- Various enforcement levels (`test_enforcement_levels.py`)
- Error message content and formatting (`test_error_messages.py`)

## Deployment considerations
- [x] This code change is ready for deployment on its own