### PR TITLE
fix: False positive - heredoc commands blocked when content mentions ai-guardian

### DIFF
--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -15,6 +15,7 @@ import fnmatch
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 from datetime import datetime, timezone, timedelta
@@ -242,6 +243,78 @@ IMMUTABLE_DENY_PATTERNS = {
         "*mv *.ai-read-deny*", "*move *.ai-read-deny*",
     ]
 }
+
+
+def _strip_bash_heredoc_content(command: str) -> str:
+    """
+    Strip heredoc content from bash commands for pattern matching.
+
+    This prevents false positives when heredoc content contains protected
+    keywords or patterns. Only the command structure is checked, not the
+    heredoc data.
+
+    Supports heredoc formats:
+    - <<EOF ... EOF
+    - <<'EOF' ... EOF (quoted)
+    - <<"EOF" ... EOF (quoted)
+    - <<-EOF ... EOF (dash format for tab stripping)
+
+    Args:
+        command: The bash command string (may be multi-line)
+
+    Returns:
+        Command with heredoc content replaced by placeholders
+
+    Example:
+        Input:  cat <<'EOF'\\nrm ai-guardian.json\\nEOF
+        Output: cat <<'EOF'\\nEOF
+    """
+    if not command or '<<' not in command:
+        return command
+
+    # Pattern to match heredoc start
+    # Groups: (1) optional dash, (2) quote if quoted, (3) delimiter if quoted, (4) delimiter if unquoted
+    heredoc_start_pattern = re.compile(
+        r"<<(-)?(?:(['\"])(\w+)\2|(\w+))",
+        re.MULTILINE
+    )
+
+    # Find all heredocs and their positions
+    replacements = []
+
+    for match in heredoc_start_pattern.finditer(command):
+        # Extract delimiter (group 3 if quoted, group 4 if unquoted)
+        delimiter = match.group(3) if match.group(3) else match.group(4)
+        heredoc_start = match.end()  # Position after the delimiter
+
+        # Find the first newline after the heredoc delimiter
+        # The heredoc content starts AFTER this newline (commands can follow on same line)
+        first_newline = command.find('\n', heredoc_start)
+        if first_newline == -1:
+            # No newline found, no heredoc content to strip
+            continue
+
+        content_start = first_newline  # Position of the newline before content
+
+        # Find the end delimiter (must be on its own line)
+        # Pattern: newline + optional whitespace + delimiter + end of line
+        end_pattern = re.compile(
+            rf'\n\s*{re.escape(delimiter)}\s*(?=\n|$)',
+            re.MULTILINE
+        )
+
+        end_match = end_pattern.search(command, content_start)
+        if end_match:
+            # Mark this range for removal (content between newlines)
+            # Remove from after the first newline to before the delimiter newline
+            replacements.append((content_start, end_match.start()))
+
+    # Apply replacements in reverse order to maintain positions
+    result = command
+    for start, end in reversed(replacements):
+        result = result[:start] + result[end:]
+
+    return result
 
 
 class ToolPolicyChecker:
@@ -853,7 +926,13 @@ class ToolPolicyChecker:
         # Bash/Shell/PowerShell: extract command from input
         if matcher == "Bash" or matcher == "Shell" or matcher == "PowerShell":
             command = tool_input.get("command")
-            return command if command else None
+            if not command:
+                return None
+            # For Bash/Shell, strip heredoc content to avoid false positives
+            # PowerShell doesn't use heredocs, so we skip this for PowerShell
+            if matcher in ["Bash", "Shell"]:
+                return _strip_bash_heredoc_content(command)
+            return command
 
         # Write: extract file_path from input
         if matcher == "Write":

--- a/tests/test_bash_heredoc.py
+++ b/tests/test_bash_heredoc.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for bash heredoc handling (Issue #151)
+
+Tests that heredoc content is properly stripped from bash commands
+before pattern matching, preventing false positives when heredoc
+content mentions protected keywords.
+"""
+
+import unittest
+from ai_guardian.tool_policy import ToolPolicyChecker, _strip_bash_heredoc_content
+
+
+class BashHeredocTest(unittest.TestCase):
+    """Test suite for bash heredoc handling"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        # Create policy checker with empty config
+        self.policy_checker = ToolPolicyChecker(config={"permissions": []})
+
+    # ========================================================================
+    # Test: _strip_bash_heredoc_content function
+    # ========================================================================
+
+    def test_strip_simple_heredoc(self):
+        """Strip content from simple heredoc"""
+        command = """cat <<EOF
+This is content
+with ai-guardian mentioned
+EOF"""
+        result = _strip_bash_heredoc_content(command)
+        # Should keep delimiters but remove content
+        self.assertIn("<<EOF", result)
+        self.assertIn("EOF", result)
+        self.assertNotIn("This is content", result)
+        self.assertNotIn("ai-guardian", result)
+
+    def test_strip_quoted_heredoc(self):
+        """Strip content from quoted heredoc (single quotes)"""
+        command = """cat <<'EOF'
+rm ai-guardian.json
+> /etc/passwd
+EOF"""
+        result = _strip_bash_heredoc_content(command)
+        self.assertIn("<<'EOF'", result)
+        self.assertNotIn("rm ai-guardian", result)
+        self.assertNotIn("> /etc/passwd", result)
+
+    def test_strip_double_quoted_heredoc(self):
+        """Strip content from double-quoted heredoc"""
+        command = """cat <<"EOF"
+dangerous content > ai-guardian
+EOF"""
+        result = _strip_bash_heredoc_content(command)
+        self.assertIn('<<"EOF"', result)
+        self.assertNotIn("dangerous content", result)
+
+    def test_strip_dash_heredoc(self):
+        """Strip content from dash heredoc (<<-EOF)"""
+        command = """cat <<-EOF
+	indented content
+	ai-guardian > file
+	EOF"""
+        result = _strip_bash_heredoc_content(command)
+        self.assertIn("<<-EOF", result)
+        self.assertNotIn("indented content", result)
+
+    def test_multiple_heredocs(self):
+        """Strip content from multiple heredocs in same command"""
+        command = """cat <<EOF1
+content1 > ai-guardian
+EOF1
+cat <<EOF2
+content2 with ai-guardian
+EOF2"""
+        result = _strip_bash_heredoc_content(command)
+        self.assertNotIn("content1", result)
+        self.assertNotIn("content2", result)
+        # Command structure should remain
+        self.assertEqual(result.count("cat"), 2)
+
+    def test_no_heredoc_unchanged(self):
+        """Commands without heredocs are unchanged"""
+        command = "echo 'hello world'"
+        result = _strip_bash_heredoc_content(command)
+        self.assertEqual(command, result)
+
+    def test_empty_command(self):
+        """Empty commands are handled gracefully"""
+        self.assertEqual(_strip_bash_heredoc_content(""), "")
+        self.assertEqual(_strip_bash_heredoc_content(None), None)
+
+    def test_heredoc_with_pipe(self):
+        """Heredoc with pipe operator is handled correctly"""
+        command = """cat <<'EOF' | pbcopy
+gh issue create --title "Doc" --body "ai-guardian > redirect"
+EOF"""
+        result = _strip_bash_heredoc_content(command)
+        self.assertIn("cat <<'EOF' | pbcopy", result)
+        self.assertNotIn("ai-guardian > redirect", result)
+
+    # ========================================================================
+    # Test: Actual command blocking behavior (integration tests)
+    # ========================================================================
+
+    def test_heredoc_mentioning_ai_guardian_is_allowed(self):
+        """
+        ISSUE #151: Heredoc content mentioning ai-guardian should be ALLOWED.
+
+        This was previously blocked by pattern "*>*ai-guardian*" matching
+        heredoc content instead of just command structure.
+        """
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": """cat <<'EOF' | pbcopy
+gh issue create --title "Documentation: Configure ai-guardian" --body "$(cat <<'EOFBODY'
+## Problem
+Users are confused about ai-guardian configuration > setup process
+EOFBODY
+)"
+EOF"""
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        # This should be ALLOWED - heredoc content should not trigger blocking
+        self.assertTrue(is_allowed, f"Heredoc with ai-guardian mention should be allowed. Error: {error_msg}")
+
+    def test_actual_redirect_to_ai_guardian_is_blocked(self):
+        """
+        Real redirect to ai-guardian files should still be BLOCKED.
+
+        This verifies the fix doesn't break legitimate blocking.
+        """
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": "echo 'malicious' > /tmp/ai-guardian.json"
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        # This should be BLOCKED - actual redirect to ai-guardian file
+        self.assertFalse(is_allowed, "Actual redirect to ai-guardian should be blocked")
+        self.assertIn("CRITICAL COMMAND BLOCKED", error_msg)
+
+    def test_heredoc_with_redirect_operator_allowed(self):
+        """
+        Heredoc content containing '>' operator should be allowed.
+
+        Pattern should only match actual shell redirects, not text content.
+        """
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": """cat <<EOF
+Markdown example:
+> This is a quote about ai-guardian
+> It should not be blocked
+EOF"""
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed, f"Heredoc with '>' in content should be allowed. Error: {error_msg}")
+
+    def test_nested_heredoc_in_command_substitution(self):
+        """
+        Test the exact example from issue #151.
+        """
+        # This is the actual command from the issue
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": """cat <<'EOF' | pbcopy
+gh issue create --title "Doc update" --body "Discussion of ai-guardian > redirect patterns"
+EOF"""
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        self.assertTrue(is_allowed,
+            "The exact command from issue #151 should be allowed. "
+            f"This is a false positive that was reported. Error: {error_msg}")
+
+    def test_heredoc_strip_preserves_actual_command_blocking(self):
+        """
+        Verify that stripping heredoc doesn't affect blocking of dangerous commands.
+        """
+        # Actual dangerous command with heredoc
+        hook_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_use": {
+                "name": "Bash",
+                "input": {
+                    "command": """rm /tmp/ai-guardian.json
+cat <<EOF
+This is just documentation
+EOF"""
+                }
+            }
+        }
+
+        is_allowed, error_msg, tool_name = self.policy_checker.check_tool_allowed(hook_data)
+
+        # The rm command should still be blocked
+        self.assertFalse(is_allowed, "Dangerous commands should still be blocked even with heredocs")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #151 - Bash commands using heredocs were incorrectly blocked when heredoc content mentioned 'ai-guardian' with redirect operators.

## Problem

The pattern `*>*ai-guardian*` was matching heredoc **content** instead of only checking command **structure**. Example blocked command:

```bash
cat <<'EOF' | pbcopy
gh issue create --title "Doc" --body "Discussion of ai-guardian > redirect"
EOF
```

This legitimate command was blocked because the heredoc content contained both `>` and `ai-guardian`.

## Solution

Implemented context-aware parsing to strip heredoc content before pattern matching:

1. **Added `_strip_bash_heredoc_content()` function** - Parses bash commands to identify and remove heredoc content
2. **Supports all heredoc formats**:
   - `<<EOF` (unquoted)
   - `<<'EOF'` (single-quoted)
   - `<<"EOF"` (double-quoted)
   - `<<-EOF` (dash format for tab stripping)
3. **Applied during check value extraction** - Heredoc content removed before immutable pattern checks

## Changes

- `src/ai_guardian/tool_policy.py`:
  - Added `import re` for regex pattern matching
  - Added `_strip_bash_heredoc_content()` function (78 lines)
  - Modified `_extract_check_value()` to strip heredocs for Bash/Shell commands
- `tests/test_bash_heredoc.py`: New comprehensive test suite (13 tests, 228 lines)

## Testing

### New Tests (13 total)
✅ All heredoc stripping unit tests pass  
✅ Issue #151 example command now allowed  
✅ Actual malicious commands still blocked  
✅ Multiple heredocs handled correctly  
✅ Heredocs with pipes preserved  

### Regression Testing
✅ All existing tests pass (633 passed, 1 skipped)  
✅ Self-protection still works correctly  
✅ No impact on other pattern matching  

### Test Coverage

```bash
pytest tests/test_bash_heredoc.py -v
# 13 passed in 0.05s

pytest --tb=short -q
# 633 passed, 1 skipped, 1 warning in 2.84s
```

## Examples

### Before (False Positive ❌)
```bash
# This was BLOCKED - false positive
cat <<'EOF'
Users confused about ai-guardian > setup
EOF
```

### After (Correctly Allowed ✅)
```bash
# Now ALLOWED - heredoc content ignored
cat <<'EOF'
Users confused about ai-guardian > setup
EOF
```

### Still Blocked (Correct Behavior ✅)
```bash
# Still BLOCKED - actual redirect to protected file
echo 'malicious' > /tmp/ai-guardian.json
```

## Impact

- **Severity**: Medium → **RESOLVED**
- **Workaround needed**: None
- **Breaking changes**: None
- **Performance impact**: Minimal (regex parsing only when command contains `<<`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)