### PR TITLE
Documentation: Clarify differences between permissions, permissions_directories, and directory_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Documentation: Clarified configuration section differences** (Issue #150)
+  - Added "Configuration Concepts" section to README explaining the three main config areas
+  - New comparison table showing differences between `permissions`, `permissions_directories`, and `directory_rules`
+  - Expanded FAQ with three new questions addressing common configuration confusion:
+    - Q: What's the difference between `permissions` and `permissions_directories`?
+    - Q: What's the difference between `permissions_directories` and `directory_rules`?
+    - Q: When should I use `permissions_directories`?
+  - Improved comments in `ai-guardian-example.json`:
+    - `permissions`: Clarified as "WHERE THE RULES LIVE" (tool execution control)
+    - `permissions_directories`: Clarified as "HOW TO AUTO-POPULATE RULES" (auto-discovery feeds INTO permissions.rules)
+    - `directory_exclusions`/`directory_rules`: Clarified as completely separate from permissions (filesystem path access control)
+  - Updated `docs/TUI.md` to explain tab relationships:
+    - Tabs 3-4 (Skills, MCP Servers) work together for tool permissions
+    - Tab 8 (Permissions Discovery) feeds INTO tabs 3-4
+    - Tab 9 (Directory Protection) is separate (filesystem access, not tool permissions)
+  - Enhanced schema descriptions in `ai-guardian-config.schema.json` for all three sections
+  - Key clarification: `permissions_directories` discovers TOOL permissions; `directory_rules` blocks filesystem PATHS
+
 ### Changed
 - **BREAKING**: Replaced `action="log"` with `action="warn"` for clearer semantics (Issue #159)
   - Old behavior: `action="log"` logged violations and showed warning to user

--- a/README.md
+++ b/README.md
@@ -699,6 +699,55 @@ Remote policies: Centrally managed, cannot be bypassed
 
 The following manual configuration is provided for reference or advanced use cases.
 
+### Configuration Concepts
+
+AI Guardian has three main configuration areas that serve distinct purposes. Understanding the difference is critical:
+
+| Configuration Section | Purpose | What It Controls | When to Use |
+|----------------------|---------|------------------|-------------|
+| **`permissions`** | Tool permission enforcement | Which **TOOLS** can run (Skills, MCP, Bash, Write, etc.) | Required for Skills; optional for enterprise MCP/Bash restrictions |
+| **`permissions_directories`** | Auto-discovery of tool permissions | Automatically populates `permissions` rules from directories/GitHub | Advanced: Dynamic permission loading from repos |
+| **`directory_rules`** | Filesystem access control | Which **PATHS** can be accessed/read (e.g., block `~/.ssh`) | Protect sensitive directories from AI access |
+
+#### How `permissions` and `permissions_directories` Work Together
+
+These two sections complement each other for tool permission management:
+
+1. **`permissions`** - WHERE THE RULES LIVE
+   - Contains the actual permission rules that are enforced
+   - Manual configuration: You explicitly list allowed/denied tools
+   - Example: `{"matcher": "Skill", "mode": "allow", "patterns": ["daf-*", "gh-cli"]}`
+
+2. **`permissions_directories`** - HOW TO AUTO-POPULATE RULES
+   - Scans directories or GitHub repos for permission files
+   - Automatically discovers and loads rules → merges into `permissions.rules`
+   - Example: Scan `~/.claude/skills/` and auto-allow all discovered skills
+
+**Data Flow:**
+```
+permissions_directories → Scan directories → Discover permission files → Generate rules → Merge into permissions.rules
+```
+
+**When to use:**
+- Use **only `permissions`**: For static, manually curated tool lists (most users)
+- Use **both together**: For dynamic discovery from shared repos (advanced users)
+- Recommended: Use `remote_configs` instead of `permissions_directories` (easier to manage)
+
+#### How `directory_rules` is DIFFERENT
+
+**CRITICAL:** Despite the similar name, `directory_rules` is **completely unrelated** to `permissions` and `permissions_directories`:
+
+- **`permissions` + `permissions_directories`**: Control which **TOOLS** can execute
+- **`directory_rules`**: Control which **PATHS** can be accessed
+
+**Example use cases:**
+- `permissions`: "Block the `rm -rf` Bash pattern" (tool permission)
+- `directory_rules`: "Block access to `~/.ssh` directory" (filesystem access)
+
+**Common confusion:**
+❌ "I want to block a tool from accessing `/etc` → use `permissions_directories`"  
+✅ "I want to block ANY tool from accessing `/etc` → use `directory_rules`"
+
 ### Claude Code
 
 Add to `~/.claude/settings.json`:
@@ -1917,6 +1966,57 @@ Instead, we recommend researching prompt injection through:
 - Security research from reputable sources
 
 For testing AI Guardian, use generic `test:` prefixed strings rather than actual attack patterns.
+
+### Q: What's the difference between `permissions` and `permissions_directories`?
+
+**A:** They work **together** for tool permission management:
+
+- **`permissions`** - WHERE THE RULES LIVE  
+  Manual configuration of which tools (Skills, MCP, Bash) are allowed/denied.  
+  Example: `{"matcher": "Skill", "mode": "allow", "patterns": ["daf-*"]}`
+
+- **`permissions_directories`** - HOW TO AUTO-POPULATE RULES  
+  Scans directories/GitHub repos for permission files and automatically merges discovered rules into `permissions.rules`.  
+  Example: Scan `~/.claude/skills/` to auto-allow all discovered skills.
+
+**Data flow:** `permissions_directories` → scan → discover → generate rules → **merge into** `permissions.rules`
+
+**Most users:** Just use `permissions` for manual configuration.  
+**Advanced users:** Use both for dynamic discovery from shared repos.  
+**Recommended:** Use `remote_configs` instead of `permissions_directories` (simpler to manage).
+
+### Q: What's the difference between `permissions_directories` and `directory_rules`?
+
+**A:** These are **completely different** features despite similar names:
+
+| Feature | Purpose | What it Controls |
+|---------|---------|------------------|
+| `permissions_directories` | Tool permission auto-discovery | Which **TOOLS** can run |
+| `directory_rules` | Filesystem access control | Which **PATHS** can be accessed |
+
+**Example:**
+- ❌ Wrong: "Block tools from accessing `/etc` → use `permissions_directories`"
+- ✅ Correct: "Block ANY tool from accessing `/etc` → use `directory_rules`"
+
+**Common confusion:** They both have "directory" in the name but:
+- `permissions_directories`: Specifies where to **find** permission rules (config source)
+- `directory_rules`: Specifies which **paths** to protect (security policy)
+
+### Q: When should I use `permissions_directories`?
+
+**A:** Only for **advanced use cases**:
+
+✅ **Use `permissions_directories` when:**
+- You have a shared GitHub/GitLab repo with team permission files
+- You maintain multiple permission files across projects
+- You want permissions to auto-update when repo changes
+
+❌ **Don't use if:**
+- You have a static list of allowed tools (use `permissions` instead)
+- You want enterprise policies (use `remote_configs` instead - much easier)
+- You're just getting started (keep it simple with manual `permissions`)
+
+**Recommendation:** Most users should use `remote_configs` for centralized policy management instead of `permissions_directories`.
 
 ## Contributing
 

--- a/ai-guardian-example.json
+++ b/ai-guardian-example.json
@@ -19,7 +19,11 @@
   "_comment16": "====================================================================",
 
   "permissions": {
-    "_comment": "NEW unified structure in v1.4.0: combines enabled flag and rules in one object",
+    "_comment": "Tool permission enforcement - WHERE THE RULES LIVE",
+    "_comment2": "Controls which TOOLS can run (Skills, MCP servers, Bash, Write, etc.)",
+    "_comment3": "This is the actual enforcement layer - rules here are checked when tools execute",
+    "_comment4": "Works with permissions_directories (auto-discovery feeds INTO this section)",
+    "_comment5": "NEW unified structure in v1.4.0: combines enabled flag and rules in one object",
     "enabled": true,
     "rules": [
       {
@@ -73,8 +77,12 @@
   },
 
   "permissions_directories": {
-    "_comment": "OPTIONAL/ADVANCED: Auto-discover from directories (most users should use remote_configs instead)",
-    "_comment2": "Use this for local development or when you can't pre-list all items",
+    "_comment": "OPTIONAL/ADVANCED: Auto-discover tool permissions - HOW TO AUTO-POPULATE RULES",
+    "_comment2": "Scans directories/GitHub repos for permission files → merges discovered rules INTO permissions.rules",
+    "_comment3": "This is NOT about blocking directories - that's directory_rules (see below)",
+    "_comment4": "Data flow: scan directories → discover permission files → generate rules → merge into permissions.rules",
+    "_comment5": "Most users should use remote_configs instead (easier to manage)",
+    "_comment6": "Use this for local development or when you can't pre-list all items",
     "_examples": [
       {
         "matcher": "Skill",
@@ -206,10 +214,15 @@
   },
 
   "directory_exclusions": {
-    "_comment": "Directory exclusions for .ai-read-deny blocking (NEW in v1.5.0)",
-    "_comment2": "Disable .ai-read-deny blocking for specific directory paths",
-    "_comment3": "CRITICAL: .ai-read-deny markers ALWAYS take precedence over exclusions",
-    "_comment4": "Config-based (safe from AI manipulation, unlike marker files)",
+    "_comment": "DEPRECATED: Use directory_rules instead (v1.6.0+). Automatically converted internally.",
+    "_comment2": "Filesystem path access control - Controls which PATHS can be accessed/read",
+    "_comment3": "⚠️ NOT RELATED to permissions_directories (despite similar names):",
+    "_comment4": "  - permissions_directories: Auto-discovers TOOL permission rules",
+    "_comment5": "  - directory_exclusions/directory_rules: Blocks AI access to specific PATHS (e.g., ~/.ssh)",
+    "_comment6": "Directory exclusions for .ai-read-deny blocking (NEW in v1.5.0)",
+    "_comment7": "Disable .ai-read-deny blocking for specific directory paths",
+    "_comment8": "CRITICAL: .ai-read-deny markers ALWAYS take precedence over exclusions",
+    "_comment9": "Config-based (safe from AI manipulation, unlike marker files)",
     "enabled": false,
     "_simple_format": "false (boolean - permanent enable/disable)",
     "paths": [],

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -310,6 +310,13 @@ Manage Skill permission rules (allow/deny patterns).
 
 #### Overview
 
+**Purpose:** Controls which **TOOLS** (Skills) the AI can execute.
+
+**Relationship to other tabs:**
+- This tab edits the `permissions.rules` section (matcher: "Skill")
+- Works with **Permissions Discovery** tab (tab 8): Auto-discovered skills feed INTO this allow/deny list
+- **NOT related** to **Directory Protection** tab (tab 9): That controls filesystem PATHS, not tool execution
+
 Skills are CLI commands exposed by AI coding assistants (e.g., `daf-cli`, `release`, `gh-cli`). This tab controls which Skills the AI can execute.
 
 #### Configuration Structure
@@ -422,6 +429,13 @@ Patterns can have expiration timestamps for temporary permissions:
 Manage MCP (Model Context Protocol) server permissions.
 
 #### Overview
+
+**Purpose:** Controls which **TOOLS** (MCP servers) the AI can invoke.
+
+**Relationship to other tabs:**
+- This tab edits the `permissions.rules` section (matcher: "mcp__*")
+- Works with **Permissions Discovery** tab (tab 8): Auto-discovered MCP permissions feed INTO this allow/deny list
+- **NOT related** to **Directory Protection** tab (tab 9): That controls filesystem PATHS, not tool execution
 
 MCP servers are external tools/services accessed via the Model Context Protocol. Examples include:
 - `mcp__notebooklm-mcp__*` - NotebookLM operations
@@ -858,6 +872,18 @@ Manage auto-discovery of permissions from local directories or GitHub repositori
 
 #### Overview
 
+**Purpose:** Auto-discover **TOOL** permissions from directories/repos and merge INTO `permissions.rules`.
+
+**Relationship to other tabs:**
+- Discovered permissions automatically populate **Skills** (tab 3) and **MCP Servers** (tab 4) allow lists
+- This is the `permissions_directories` configuration section
+- **Data flow:** Scan directories → Discover permission files → Generate rules → **Merge into** `permissions.rules`
+- **NOT related** to **Directory Protection** tab (tab 9): Despite similar names, this discovers TOOL permissions, not filesystem path restrictions
+
+**Critical distinction:**
+- **This tab (Permissions Discovery):** WHERE to find tool permission files (config source)
+- **Directory Protection tab:** WHICH paths to block from AI access (security policy)
+
 Permissions Discovery allows AI Guardian to automatically load permission rules from specified directories or GitHub repos. This is useful for:
 - **Shared team permissions**: Store in Git, auto-load across team
 - **Project-specific rules**: Each repo defines its own required permissions
@@ -1012,6 +1038,21 @@ Permissions from multiple discovered files are merged:
 Manage directory exclusions and `.ai-read-deny` marker scanning.
 
 #### Overview
+
+**Purpose:** Controls which **PATHS** (directories/files) the AI can access/read.
+
+**Relationship to other tabs:**
+- This is the `directory_rules` (or `directory_exclusions` deprecated) configuration section
+- **COMPLETELY SEPARATE** from **Permissions Discovery** tab (tab 8)
+- **NOT related** to Skills/MCP permissions (tabs 3-4)
+
+**Critical distinction - avoid confusion:**
+- **Permissions Discovery tab (8):** Auto-discovers TOOL permissions (which tools can run)
+- **This tab (Directory Protection):** Blocks filesystem PATHS (e.g., block `~/.ssh` directory)
+
+**Common mistake:**  
+❌ "I want to block a tool from accessing `/etc` → use Permissions Discovery"  
+✅ "I want to block ANY tool from accessing `/etc` → use Directory Protection"
 
 Directory Protection prevents AI agents from reading sensitive directories by:
 1. **Exclusion paths**: Manually specified directories to block

--- a/src/ai_guardian/schemas/ai-guardian-config.schema.json
+++ b/src/ai_guardian/schemas/ai-guardian-config.schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "permissions": {
       "type": "object",
-      "description": "Tool permissions configuration (NEW unified structure in v1.4.0). Controls whether AI Guardian enforces tool permission rules and defines the permission rules for tools (Skills, MCP servers, built-in tools like Bash/Write/Read). Default: Built-in tools ALLOW, Skills and MCP servers BLOCK unless explicitly allowed.",
+      "description": "Tool permissions configuration - WHERE THE RULES LIVE. Controls whether AI Guardian enforces tool permission rules and defines the permission rules for tools (Skills, MCP servers, built-in tools like Bash/Write/Read). Works with permissions_directories (auto-discovery feeds INTO this section). Default: Built-in tools ALLOW, Skills and MCP servers BLOCK unless explicitly allowed. NEW unified structure in v1.4.0.",
       "properties": {
         "enabled": {
           "oneOf": [
@@ -67,7 +67,7 @@
           }
         }
       ],
-      "description": "OPTIONAL/ADVANCED: Auto-discover permissions from directories. Most users should use remote_configs instead. Supports both object format (allow/deny arrays) and direct array format."
+      "description": "OPTIONAL/ADVANCED: Auto-discover tool permissions - HOW TO AUTO-POPULATE RULES. Scans directories/GitHub repos for permission files and merges discovered rules INTO permissions.rules. Data flow: scan directories → discover permission files → generate rules → merge into permissions.rules. NOT related to directory_rules (filesystem path access control). Most users should use remote_configs instead. Supports both object format (allow/deny arrays) and direct array format."
     },
     "remote_configs": {
       "type": "object",
@@ -430,7 +430,7 @@
         },
         {
           "type": "object",
-          "description": "Order-based directory access control rules (NEW in v1.6.0). Rules are evaluated sequentially with last match winning. Supports flexible allow/deny patterns for enterprise skill allowlists and path restrictions.",
+          "description": "Filesystem path access control - Controls which PATHS can be accessed/read. Order-based directory access control rules (NEW in v1.6.0). Rules are evaluated sequentially with last match winning. Supports flexible allow/deny patterns for enterprise skill allowlists and path restrictions. COMPLETELY SEPARATE from permissions_directories (which auto-discovers TOOL permissions, not path restrictions). Common confusion: permissions_directories = where to find tool permission config, directory_rules = which paths to protect.",
           "properties": {
             "action": {
               "type": "string",
@@ -471,7 +471,7 @@
     },
     "directory_exclusions": {
       "type": "object",
-      "description": "DEPRECATED: Use directory_rules instead. Directory exclusions can override .ai-read-deny blocking (v1.5.0). Automatically converted to directory_rules internally.",
+      "description": "DEPRECATED: Use directory_rules instead. Filesystem path access control - Controls which PATHS can be accessed/read. NOT related to permissions_directories (which auto-discovers TOOL permissions). Directory exclusions can override .ai-read-deny blocking (v1.5.0). Automatically converted to directory_rules internally.",
       "deprecated": true,
       "properties": {
         "enabled": {
@@ -580,7 +580,7 @@
     "directory_entry": {
       "type": "object",
       "required": ["url"],
-      "description": "Directory to scan for auto-discovery of permissions. In object format (allow/deny arrays), mode is determined by which array the entry is in. In array format, mode defaults to 'allow' if not specified.",
+      "description": "Directory to scan for auto-discovery of tool permissions (NOT filesystem path blocking). Scans directory or GitHub repo for permission files and generates tool permission rules. Purpose: Auto-populate permissions.rules, not block directories. In object format (allow/deny arrays), mode is determined by which array the entry is in. In array format, mode defaults to 'allow' if not specified.",
       "properties": {
         "matcher": {
           "type": "string",


### PR DESCRIPTION
## Summary

Addresses #150 - documentation confusion about three similarly-named configuration sections that serve completely different purposes.

This PR adds comprehensive documentation to clarify the critical differences between:
- **`permissions`** - WHERE THE RULES LIVE (which TOOLS can run)
- **`permissions_directories`** - HOW TO AUTO-POPULATE RULES (auto-discovery feeds INTO permissions.rules)
- **`directory_rules`** - Filesystem path access control (which PATHS can be accessed)

## Changes

### README.md
- ✅ Added "Configuration Concepts" section with comparison table
- ✅ Added three new FAQ entries explaining configuration differences
- ✅ Clarified data flow: `permissions_directories` → scan → discover → **merge into** `permissions.rules`

### ai-guardian-example.json
- ✅ Improved comments for `permissions` section
- ✅ Improved comments for `permissions_directories` section  
- ✅ Improved comments for `directory_exclusions` section
- ✅ Added explicit warnings about unrelated features with similar names

### docs/TUI.md
- ✅ Updated Skills tab (tab 3) to explain relationship to Permissions Discovery (tab 8)
- ✅ Updated MCP Servers tab (tab 4) to explain relationship to Permissions Discovery (tab 8)
- ✅ Updated Permissions Discovery tab (tab 8) to clarify it feeds INTO tabs 3-4
- ✅ Updated Directory Protection tab (tab 9) to emphasize separation from permissions

### src/ai_guardian/schemas/ai-guardian-config.schema.json
- ✅ Enhanced `permissions` description
- ✅ Enhanced `permissions_directories` description with data flow explanation
- ✅ Enhanced `directory_rules` description with distinction from permissions_directories
- ✅ Enhanced `directory_exclusions` description
- ✅ Enhanced `directory_entry` description

### CHANGELOG.md
- ✅ Added entry under [Unreleased] → Added section

## Key Clarification

**CRITICAL:** Despite similar names, `permissions_directories` and `directory_rules` are **completely unrelated**:

| Feature | Purpose | What it Controls |
|---------|---------|------------------|
| `permissions_directories` | Tool permission auto-discovery | Which **TOOLS** can run |
| `directory_rules` | Filesystem access control | Which **PATHS** can be accessed |

## Testing

This is a documentation-only change. No code changes were made.

- [x] Verified all documentation sections are clear and consistent
- [x] Verified comparison table is accurate
- [x] Verified FAQ answers are helpful
- [x] Verified TUI.md tab descriptions are clear
- [x] Verified schema descriptions are enhanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>