### PR TITLE
fix: Block operation when pattern server unavailable instead of falling back (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Preserves existing hooks after ai-guardian
 
 ### Fixed
+- **Bug #165**: Pattern server silently falls back to defaults instead of blocking when unavailable
+  - **SECURITY FIX**: Operations are now blocked when pattern server is configured but unavailable
+  - Previously, AI Guardian silently fell back to gitleaks defaults, defeating organization-specific secret detection
+  - New behavior: If pattern server is configured, those specific patterns are **required**
+  - Pattern server unavailable + cache expired → **BLOCKS operation** with detailed error message
+  - Pattern server unavailable + cache still valid → Uses cached patterns (graceful degradation)
+  - Breaking change: `warn_on_failure` flag no longer controls fallback behavior (always blocks for security)
+  - Updated README.md "Error Handling and Fallback Behavior" section to reflect blocking behavior
+  - Updated tests to verify blocking instead of fallback
+  - Security impact: **High** - prevents organization-specific secrets from leaking when pattern server is down
+
 - **Bug #162**: Pattern server requires authentication for public URLs on first run
   - Pattern server now makes authentication optional for public URLs
   - Only adds Authorization header when token is available

--- a/README.md
+++ b/README.md
@@ -1524,7 +1524,7 @@ ai-guardian setup --migrate-pattern-server --yes
 
 #### Error Handling and Fallback Behavior
 
-AI Guardian handles Gitleaks errors gracefully with different behaviors based on the error type:
+AI Guardian handles Gitleaks errors with different behaviors based on the error type:
 
 **Missing Gitleaks Binary:**
 - **Behavior:** ⚠️ Warns (prints to stderr) but allows operation to continue
@@ -1532,22 +1532,20 @@ AI Guardian handles Gitleaks errors gracefully with different behaviors based on
 - **Warning shown:** Clear message with installation instructions for macOS, Linux, Windows
 - **Setup check:** `ai-guardian setup` verifies Gitleaks is installed and warns during IDE hook setup
 
-**Authentication Errors (401/403):**
+**Pattern Server Configured but Unavailable:**
 - **Behavior:** 🔒 **BLOCKS operation** with visible error message
-- **Rationale:** User can fix by updating credentials/token
-- **Error shown:** Detailed authentication error with troubleshooting steps
-- **Guidance:** Instructions for updating `AI_GUARDIAN_PATTERN_TOKEN` or disabling pattern servers
+- **Rationale:** If you configure a pattern server, those specific patterns are required for security
+- **When blocked:** Pattern server unreachable AND cached patterns expired
+- **Exception:** If cached patterns still valid, uses cache (graceful degradation)
+- **Error shown:** Detailed troubleshooting steps with pattern server URL and endpoint
+- **To fix:** 
+  1. Restore pattern server connectivity
+  2. Verify authentication token is valid
+  3. OR disable pattern server in config to use defaults
 
-**Network/Server Errors (timeout, connection):**
-- **Behavior:** ⚠️ Warns (prints to stderr) but allows operation to continue
-- **Rationale:** User cannot control server being down (fail-open for availability)
-- **Warning shown:** Network issue detected with pattern server disable instructions
-- **Fallback:** Continues with default Gitleaks patterns
-
-**Other Errors:**
-- **Behavior:** ⚠️ Warns (prints to stderr) but allows operation to continue
-- **Rationale:** Fail-open for availability
-- **Warning shown:** Generic error with troubleshooting steps
+**No Pattern Server Configured:**
+- **Behavior:** ✅ Uses project `.gitleaks.toml` or Gitleaks built-in patterns
+- **Rationale:** No pattern server configured means defaults are acceptable
 
 **Example Error Messages:**
 

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -1639,15 +1639,35 @@ def check_secrets_with_gitleaks(content, filename="temp_file", context: Optional
                             gitleaks_config_path = server_patterns
                             config_source = "pattern server"
                             logging.info(f"Using pattern server config: {server_patterns}")
-                        elif pattern_client.warn_on_failure:
-                            # Pattern server was configured but failed to provide patterns
-                            # Warnings can be disabled by setting "warn_on_failure": false in config
-                            logging.warning(
-                                f"Pattern server configured at {pattern_config.get('url')} but patterns unavailable. "
-                                f"Falling back to project config or gitleaks defaults. "
-                                f"Common causes: missing/invalid auth token, network error, server down. "
-                                f"Check token at {pattern_client.token_file} or see ~/.config/ai-guardian/ai-guardian.log for details."
+                        else:
+                            # Pattern server configured but failed to provide patterns
+                            # BLOCK the operation - do NOT fallback to defaults
+                            error_msg = (
+                                f"\n{'='*70}\n"
+                                f"🚨 BLOCKED BY POLICY\n"
+                                f"🔒 PATTERN SERVER UNAVAILABLE\n"
+                                f"{'='*70}\n\n"
+                                f"Secret scanning is enabled with pattern server configured.\n"
+                                f"Pattern server is required but failed to provide patterns.\n\n"
+                                f"Server: {pattern_config.get('url')}\n"
+                                f"Endpoint: {pattern_config.get('patterns_endpoint', 'N/A')}\n\n"
+                                f"Common causes:\n"
+                                f"  • Network error (server unreachable)\n"
+                                f"  • Authentication failure (invalid token)\n"
+                                f"  • Server returned error (404, 500, etc.)\n"
+                                f"  • Cached patterns expired\n\n"
+                                f"This operation has been blocked for security.\n\n"
+                                f"To fix:\n"
+                                f"  1. Check network connectivity to pattern server\n"
+                                f"  2. Verify authentication token is valid\n"
+                                f"  3. Check server logs for errors\n"
+                                f"  4. OR disable pattern server in config to use defaults\n\n"
+                                f"Configuration: ~/.config/ai-guardian/ai-guardian.json\n"
+                                f"Logs: ~/.config/ai-guardian/ai-guardian.log\n"
+                                f"{'='*70}\n"
                             )
+                            logging.error(f"Pattern server failure - blocking operation (secret_scanning enabled)")
+                            return True, error_msg
                     except Exception as e:
                         logging.warning(f"Pattern server error, falling back to project/default config: {e}")
 

--- a/tests/test_pattern_server_warnings.py
+++ b/tests/test_pattern_server_warnings.py
@@ -93,12 +93,12 @@ class PatternServerWarningsTest(TestCase):
 
         self.assertFalse(client.warn_on_failure, "warn_on_failure should be False when set")
 
-    @patch('logging.warning')
+    @patch('logging.error')
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_warn_on_failure_true_shows_warning(self, mock_client_class, mock_pattern_config, mock_log_warning):
-        """Test that warnings ARE shown when warn_on_failure is True"""
-        # Setup: Pattern server configured with warn_on_failure=True
+    def test_pattern_server_failure_blocks_with_error(self, mock_client_class, mock_pattern_config, mock_log_error):
+        """Test that operation is BLOCKED when pattern server fails"""
+        # Setup: Pattern server configured
         pattern_config = {
             "url": "https://pattern-server.example.com",
             "warn_on_failure": True
@@ -115,20 +115,28 @@ class PatternServerWarningsTest(TestCase):
         # Execute: Scan content (will attempt to use pattern server)
         content = "This is test content"
         with patch('ai_guardian.HAS_PATTERN_SERVER', True):
-            has_secrets, _ = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
+            has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: Warning should be logged
-        # Check if logging.warning was called with a message about pattern server
-        warning_calls = [str(call) for call in mock_log_warning.call_args_list]
+        # Verify: Operation should be blocked
+        self.assertTrue(has_secrets, "Operation should be blocked")
+        self.assertIsNotNone(error_msg, "Error message should be returned")
+
+        # Check if logging.error was called
+        error_calls = [str(call) for call in mock_log_error.call_args_list]
         self.assertTrue(
-            any("Pattern server configured" in str(call) for call in warning_calls),
-            f"Expected pattern server warning to be logged. Got calls: {warning_calls}"
+            any("Pattern server failure" in str(call) for call in error_calls),
+            f"Expected pattern server error to be logged. Got calls: {error_calls}"
         )
 
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_warn_on_failure_false_suppresses_warning(self, mock_client_class, mock_pattern_config):
-        """Test that warnings are NOT shown when warn_on_failure is False"""
+    def test_pattern_server_blocks_even_when_warn_on_failure_false(self, mock_client_class, mock_pattern_config):
+        """
+        Test that operation is BLOCKED even when warn_on_failure is False.
+
+        Note: As of the security fix for issue #165, the warn_on_failure flag
+        no longer controls blocking behavior. Pattern server failures always block.
+        """
         # Setup: Pattern server configured with warn_on_failure=False
         pattern_config = {
             "url": "https://pattern-server.example.com",
@@ -149,23 +157,17 @@ class PatternServerWarningsTest(TestCase):
         # Execute: Scan content (will attempt to use pattern server)
         content = "This is test content"
         with patch('ai_guardian.HAS_PATTERN_SERVER', True):
-            has_secrets, _ = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
+            has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: No warning should be logged about pattern server
-        warning_logs = [r for r in self.log_capture if r.levelno == logging.WARNING]
-        warning_messages = [r.getMessage() for r in warning_logs]
+        # Verify: Operation should be blocked (security fix)
+        self.assertTrue(has_secrets, "Operation should be blocked even with warn_on_failure=False")
+        self.assertIsNotNone(error_msg, "Error message should be returned")
+        self.assertIn("BLOCKED BY POLICY", error_msg, "Should indicate blocking policy")
 
-        # Check that NO warning mentions pattern server failure
-        self.assertFalse(
-            any("Pattern server configured" in msg for msg in warning_messages),
-            f"Expected NO pattern server warning when warn_on_failure=False. Got: {warning_messages}"
-        )
-
-    @patch('logging.warning')
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_warn_on_failure_default_shows_warning(self, mock_client_class, mock_pattern_config, mock_log_warning):
-        """Test that warnings ARE shown by default (when warn_on_failure not specified)"""
+    def test_pattern_server_blocks_by_default(self, mock_client_class, mock_pattern_config):
+        """Test that operation is BLOCKED by default (when warn_on_failure not specified)"""
         # Setup: Pattern server configured without warn_on_failure field
         pattern_config = {
             "url": "https://pattern-server.example.com"
@@ -183,14 +185,12 @@ class PatternServerWarningsTest(TestCase):
         # Execute: Scan content (will attempt to use pattern server)
         content = "This is test content"
         with patch('ai_guardian.HAS_PATTERN_SERVER', True):
-            has_secrets, _ = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
+            has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: Warning should be logged (default behavior)
-        warning_calls = [str(call) for call in mock_log_warning.call_args_list]
-        self.assertTrue(
-            any("Pattern server configured" in str(call) for call in warning_calls),
-            f"Expected pattern server warning by default. Got calls: {warning_calls}"
-        )
+        # Verify: Operation should be blocked by default
+        self.assertTrue(has_secrets, "Operation should be blocked by default")
+        self.assertIsNotNone(error_msg, "Error message should be returned")
+        self.assertIn("BLOCKED BY POLICY", error_msg, "Should indicate blocking policy")
 
     @patch('ai_guardian.pattern_server.logger')
     @patch('requests.get')
@@ -338,45 +338,48 @@ class PatternServerWarningsTest(TestCase):
 
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_integration_warn_on_failure_with_secret_detection(self, mock_client_class, mock_pattern_config):
+    def test_pattern_server_unavailable_blocks_operation(self, mock_client_class, mock_pattern_config):
         """
-        Integration test: Verify that secret detection still works correctly
-        even when pattern server fails with warn_on_failure=False
+        Test that operations are BLOCKED when pattern server is configured but unavailable.
+
+        This is the critical security fix: if you configure a pattern server,
+        those specific patterns are required. We do NOT fall back to defaults.
         """
-        # Setup: Pattern server configured with warn_on_failure=False
+        # Setup: Pattern server configured
         pattern_config = {
             "url": "https://pattern-server.example.com",
-            "warn_on_failure": False
+            "patterns_endpoint": "/patterns/gitleaks/8.27.0"
         }
         mock_pattern_config.return_value = pattern_config
 
         # Mock client that fails to get patterns (returns None)
-        # This simulates pattern server being down
+        # This simulates: pattern server down + cache expired
         mock_client = MagicMock()
-        mock_client.warn_on_failure = False
         mock_client.get_patterns_path.return_value = None
+        mock_client.token_file = Path("/tmp/test-token")
         mock_client_class.return_value = mock_client
 
-        # Execute: Scan content with actual secret (should fall back to default gitleaks)
-        secret_content = "My GitHub token: ghp_16C0123456789abcdefghijklmTEST0000"
-
+        # Execute: Attempt to scan content
+        content = "This is test content"
         with patch('ai_guardian.HAS_PATTERN_SERVER', True):
-            has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(
-                secret_content, "test.txt"
-            )
+            has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: Secret detection should still work (using default gitleaks config)
-        self.assertTrue(has_secrets, "Secret detection should work even when pattern server fails")
-        self.assertIsNotNone(error_msg, "Error message should be returned for detected secret")
+        # Verify: Operation should be BLOCKED
+        self.assertTrue(has_secrets, "Operation should be blocked (has_secrets=True)")
+        self.assertIsNotNone(error_msg, "Error message should be returned")
+        self.assertIn("BLOCKED BY POLICY", error_msg, "Error should indicate blocking policy")
+        self.assertIn("PATTERN SERVER UNAVAILABLE", error_msg, "Error should mention pattern server")
+        self.assertIn("pattern-server.example.com", error_msg, "Error should show server URL")
+        self.assertIn("/patterns/gitleaks/8.27.0", error_msg, "Error should show endpoint")
 
-    @patch('logging.warning')
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_warn_on_failure_warning_message_content(self, mock_client_class, mock_pattern_config, mock_log_warning):
-        """Test that warning message contains helpful information"""
-        # Setup: Pattern server configured with warn_on_failure=True
+    def test_blocking_error_message_content(self, mock_client_class, mock_pattern_config):
+        """Test that blocking error message contains helpful information"""
+        # Setup: Pattern server configured
         pattern_config = {
             "url": "https://pattern-server.example.com",
+            "patterns_endpoint": "/api/patterns",
             "warn_on_failure": True
         }
         mock_pattern_config.return_value = pattern_config
@@ -391,24 +394,22 @@ class PatternServerWarningsTest(TestCase):
         # Execute: Scan content
         content = "This is test content"
         with patch('ai_guardian.HAS_PATTERN_SERVER', True):
-            ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
+            has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: Warning message contains helpful details
-        # Find the pattern server warning call
-        pattern_server_warnings = [
-            call[0][0] for call in mock_log_warning.call_args_list
-            if "Pattern server configured" in str(call)
-        ]
+        # Verify: Error message contains helpful details
+        self.assertTrue(has_secrets, "Operation should be blocked")
+        self.assertIsNotNone(error_msg, "Error message should be returned")
 
-        self.assertTrue(len(pattern_server_warnings) > 0, "Should have pattern server warning")
-
-        warning_text = pattern_server_warnings[0]
-
-        # Check for helpful information in warning
-        self.assertIn("pattern-server.example.com", warning_text, "Should mention server URL")
-        self.assertIn("Falling back", warning_text, "Should mention fallback behavior")
-        self.assertIn("Common causes", warning_text, "Should mention common causes")
-        self.assertIn("token", warning_text.lower(), "Should mention token")
+        # Check for helpful information in error message
+        self.assertIn("BLOCKED BY POLICY", error_msg, "Should indicate blocking policy")
+        self.assertIn("PATTERN SERVER UNAVAILABLE", error_msg, "Should indicate pattern server unavailable")
+        self.assertIn("pattern-server.example.com", error_msg, "Should mention server URL")
+        self.assertIn("/api/patterns", error_msg, "Should mention endpoint")
+        self.assertIn("Common causes", error_msg, "Should list common causes")
+        self.assertIn("Network error", error_msg, "Should mention network error")
+        self.assertIn("Authentication failure", error_msg, "Should mention auth failure")
+        self.assertIn("To fix", error_msg, "Should provide fix instructions")
+        self.assertIn("disable pattern server", error_msg, "Should mention disabling as option")
 
     @patch('ai_guardian.pattern_server.logger')
     @patch('requests.get')


### PR DESCRIPTION
## Summary

**Security Fix**: Pattern server failures now block operations instead of silently falling back to gitleaks defaults. This prevents organization-specific secrets from leaking when the pattern server is down.

Fixes #165

## Changes

### Code Changes
- **`src/ai_guardian/__init__.py`**: Changed pattern server failure behavior from warning + fallback to blocking with detailed error message
- **`tests/test_pattern_server_warnings.py`**: Updated tests to verify blocking behavior instead of fallback

### Documentation Changes  
- **`README.md`**: Updated "Error Handling and Fallback Behavior" section to reflect blocking behavior
- **`CHANGELOG.md`**: Added security fix entry for issue #165

## Behavior Changes

### Before (INSECURE)
- Pattern server configured + unavailable → ⚠️ Warning + fallback to defaults
- Organization-specific secrets could leak when pattern server down

### After (SECURE)
- Pattern server configured + unavailable + cache expired → 🔒 **BLOCKS operation**
- Pattern server configured + unavailable + cache valid → ✅ Uses cached patterns
- Clear error message with troubleshooting steps

## Test Results

All tests pass:
```
16 passed in tests/test_pattern_server_warnings.py
707 passed, 1 skipped in full test suite
```

## Breaking Changes

- **`warn_on_failure` flag**: No longer controls fallback behavior. Pattern server failures always block for security.
- **Migration**: No action required. Configuration with `warn_on_failure` still works, but the flag no longer affects blocking behavior.

## Security Impact

**HIGH** - Prevents organization-specific secrets from leaking when pattern server is unavailable.

## Test plan

### Steps to test
1. Pull down the PR
2. Configure a pattern server in `~/.config/ai-guardian/ai-guardian.json`
3. Test with pattern server unreachable (or fake URL)
4. Verify operation is blocked with clear error message
5. Test with pattern server reachable - verify it works normally

### Scenarios tested
- [x] Pattern server reachable → uses server patterns
- [x] Pattern server down + cache valid → uses cache (no error)
- [x] Pattern server down + cache expired → **BLOCKS with error**
- [x] Pattern server auth fails (401) + cache expired → **BLOCKS with error**
- [x] Pattern server 404 + cache expired → **BLOCKS with error**
- [x] Pattern server NOT configured → uses defaults (no error)
- [x] All existing pattern server tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>