### PR TITLE
itdove/ai-guardian#178: Add default config creation to ai-guardian setup command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Default config creation in setup command** (Issue #178)
+  - New `--create-config` flag for `ai-guardian setup` command to create default `ai-guardian.json` config file
+  - Two configuration modes:
+    - Default (secure): Secret scanning and prompt injection enabled, Skills/MCP blocked by default
+    - Permissive (`--permissive`): Same security features, but all tools allowed (permissions disabled)
+  - `--dry-run` flag shows config preview without creating file
+  - Improves onboarding experience - no manual config file copying required
+  - Example usage:
+    - `ai-guardian setup --create-config` - Create secure default config
+    - `ai-guardian setup --create-config --permissive` - Create permissive config
+    - `ai-guardian setup --create-config --dry-run` - Preview config without creating
+  - Config includes:
+    - Secret scanning with LeakTK patterns
+    - Prompt injection detection (medium sensitivity)
+    - Permission rules (Skills/MCP blocked by default in secure mode)
+    - Empty directory rules (no restrictions)
+    - Remote configs section for enterprise policies
+
 - **Improved logging for skill and prompt injection violations** (Issue #168)
   - Tool permission violations now include tool-specific details in logs:
     - Skill tool: Shows skill name and args parameter (e.g., `(skill='daf-jira', args='view AAP-12345')`)

--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -2608,6 +2608,16 @@ def main():
             action="store_true",
             help="Skip confirmation prompts"
         )
+        setup_parser.add_argument(
+            "--create-config",
+            action="store_true",
+            help="Create default ai-guardian.json config file"
+        )
+        setup_parser.add_argument(
+            "--permissive",
+            action="store_true",
+            help="Use permissive config (permissions disabled, all tools allowed)"
+        )
 
         # Violations subcommand
         violations_parser = subparsers.add_parser(
@@ -2653,7 +2663,9 @@ def main():
                 dry_run=args.dry_run,
                 force=args.force,
                 interactive=not args.yes,
-                migrate_pattern_server=args.migrate_pattern_server
+                migrate_pattern_server=args.migrate_pattern_server,
+                create_config=args.create_config,
+                permissive=args.permissive
             )
             return 0 if success else 1
 

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -850,11 +850,6 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             ]
         },
 
-        "directory_rules": {
-            "enabled": True,
-            "rules": []
-        },
-
         "remote_configs": {
             "urls": []
         }

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -807,6 +807,7 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
     config = {
         "$schema": "https://raw.githubusercontent.com/itdove/ai-guardian/main/src/ai_guardian/schemas/ai-guardian-config.schema.json",
 
+        "_comment_secret_scanning": "Scan for secrets (API keys, tokens, passwords) using Gitleaks patterns",
         "secret_scanning": {
             "enabled": True,
             "pattern_server": {
@@ -821,6 +822,7 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             }
         },
 
+        "_comment_prompt_injection": "Detect and block prompt injection attacks that try to manipulate AI behavior",
         "prompt_injection": {
             "enabled": True,
             "detector": "heuristic",
@@ -832,6 +834,7 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             "ignore_files": []
         },
 
+        "_comment_permissions": "Control which tools (Skills, MCP servers, Bash, etc.) are allowed to run",
         "permissions": {
             "enabled": not permissive,
             "rules": [] if permissive else [
@@ -850,6 +853,18 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             ]
         },
 
+        "_comment_directory_rules": "OPTIONAL: Control AI access to specific directories (e.g., block ~/.ssh). See ai-guardian-example.json for examples.",
+        "_directory_rules_example": {
+            "action": "block",
+            "rules": [
+                {
+                    "mode": "deny",
+                    "paths": ["~/.ssh/**", "~/.aws/**"]
+                }
+            ]
+        },
+
+        "_comment_remote_configs": "Load additional policies from remote URLs (for enterprise/team policies)",
         "remote_configs": {
             "urls": []
         }

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -828,14 +828,8 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             "max_score_threshold": 0.75,
             "allowlist_patterns": [],
             "custom_patterns": [],
-            "ignore_tools": [
-                "Skill:code-review",
-                "Skill:security-review"
-            ],
-            "ignore_files": [
-                "**/.claude/skills/code-review/**",
-                "**/.claude/skills/security-review/**"
-            ]
+            "ignore_tools": [],
+            "ignore_files": []
         },
 
         "permissions": {

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -737,16 +737,150 @@ class IDESetup:
             return False, f"Error migrating pattern_server config: {e}"
 
 
+def create_default_config(
+    permissive: bool = False,
+    dry_run: bool = False
+) -> Tuple[bool, str]:
+    """
+    Create default ai-guardian.json config file.
+
+    Args:
+        permissive: If True, use permissive config (permissions disabled)
+        dry_run: If True, show what would be created without writing
+
+    Returns:
+        tuple: (success: bool, message: str)
+    """
+    try:
+        config_dir = get_config_dir()
+        config_path = config_dir / "ai-guardian.json"
+
+        # Check if config already exists
+        if config_path.exists() and not dry_run:
+            return False, f"Config already exists: {config_path}"
+
+        # Generate config based on mode
+        config = _get_default_config_template(permissive)
+
+        if dry_run:
+            message = f"[DRY RUN] Would create {config_path}:\n\n"
+            message += json.dumps(config, indent=2)
+            return True, message
+
+        # Ensure directory exists
+        config_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write config
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(config, f, indent=2)
+            f.write('\n')
+
+        message = f"✓ Created default config: {config_path}\n"
+        message += f"\n  Security settings:\n"
+        message += f"  • Secret scanning: Enabled (LeakTK patterns)\n"
+        message += f"  • Prompt injection: Enabled (medium sensitivity)\n"
+
+        if permissive:
+            message += f"  • Permissions: Disabled (all tools allowed)\n"
+        else:
+            message += f"  • Permissions: Enabled (Skills/MCP blocked by default)\n"
+            message += f"\n  Next steps:\n"
+            message += f"  1. Run 'ai-guardian tui' to configure allowed skills\n"
+            message += f"  2. Or edit {config_path} manually\n"
+
+        return True, message
+
+    except Exception as e:
+        return False, f"Error creating default config: {e}"
+
+
+def _get_default_config_template(permissive: bool = False) -> Dict:
+    """
+    Get default config template based on mode.
+
+    Args:
+        permissive: If True, return permissive config (permissions disabled)
+
+    Returns:
+        dict: Default configuration
+    """
+    config = {
+        "$schema": "https://raw.githubusercontent.com/itdove/ai-guardian/main/src/ai_guardian/schemas/ai-guardian-config.schema.json",
+
+        "secret_scanning": {
+            "enabled": True,
+            "pattern_server": {
+                "url": "https://raw.githubusercontent.com/leaktk/patterns/main/target",
+                "patterns_endpoint": "/patterns/gitleaks/8.27.0",
+                "warn_on_failure": True,
+                "cache": {
+                    "path": "~/.cache/ai-guardian/patterns.toml",
+                    "refresh_interval_hours": 12,
+                    "expire_after_hours": 168
+                }
+            }
+        },
+
+        "prompt_injection": {
+            "enabled": True,
+            "detector": "heuristic",
+            "sensitivity": "medium",
+            "max_score_threshold": 0.75,
+            "allowlist_patterns": [],
+            "custom_patterns": [],
+            "ignore_tools": [
+                "Skill:code-review",
+                "Skill:security-review"
+            ],
+            "ignore_files": [
+                "**/.claude/skills/code-review/**",
+                "**/.claude/skills/security-review/**"
+            ]
+        },
+
+        "permissions": {
+            "enabled": not permissive,
+            "rules": [] if permissive else [
+                {
+                    "_comment": "Skills - Blocked by default. Add allow rules via TUI.",
+                    "matcher": "Skill",
+                    "mode": "deny",
+                    "patterns": ["*"]
+                },
+                {
+                    "_comment": "MCP Servers - Blocked by default. Add allow rules via TUI.",
+                    "matcher": "mcp__*",
+                    "mode": "deny",
+                    "patterns": ["*"]
+                }
+            ]
+        },
+
+        "directory_rules": {
+            "enabled": True,
+            "rules": []
+        },
+
+        "remote_configs": {
+            "urls": []
+        }
+    }
+
+    return config
+
+
 def setup_hooks(
     ide_type: Optional[str] = None,
     remote_config_url: Optional[str] = None,
     dry_run: bool = False,
     force: bool = False,
     interactive: bool = True,
-    migrate_pattern_server: bool = False
+    migrate_pattern_server: bool = False,
+    create_config: bool = False,
+    permissive: bool = False
 ) -> bool:
     """
-    Setup IDE hooks with optional remote config.
+    Setup IDE hooks with optional remote config and default config creation.
 
     Args:
         ide_type: IDE type ('claude' or 'cursor') or None for auto-detect
@@ -755,11 +889,23 @@ def setup_hooks(
         force: If True, overwrite existing hooks
         interactive: If True, prompt user for confirmation
         migrate_pattern_server: If True, check and migrate old pattern_server config
+        create_config: If True, create default ai-guardian.json config
+        permissive: If True with create_config, use permissive config (permissions disabled)
 
     Returns:
         bool: True if successful, False otherwise
     """
     setup = IDESetup()
+
+    # Handle default config creation if requested
+    if create_config:
+        success, message = create_default_config(permissive=permissive, dry_run=dry_run)
+        print(message)
+        if not success:
+            return False
+        # If only creating config (no IDE setup or remote config), return early
+        if ide_type is None and not remote_config_url and not migrate_pattern_server:
+            return success
 
     # Handle pattern_server migration if requested
     if migrate_pattern_server:

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -2254,12 +2254,30 @@ class ToolPolicyChecker:
         remote_entries = []
 
         if local_config and "remote_configs" in local_config:
-            for entry in local_config["remote_configs"]:
-                remote_entries.append((entry, local_config_path))
+            # Handle both formats: dict with urls key (new) or direct list (old)
+            remote_config_data = local_config["remote_configs"]
+            if isinstance(remote_config_data, dict):
+                # New format: {"urls": [...], "refresh_interval_hours": 12, ...}
+                urls = remote_config_data.get("urls", [])
+                for entry in urls:
+                    remote_entries.append((entry, local_config_path))
+            else:
+                # Old format: direct list
+                for entry in remote_config_data:
+                    remote_entries.append((entry, local_config_path))
 
         if user_config and "remote_configs" in user_config:
-            for entry in user_config["remote_configs"]:
-                remote_entries.append((entry, user_config_path))
+            # Handle both formats: dict with urls key (new) or direct list (old)
+            remote_config_data = user_config["remote_configs"]
+            if isinstance(remote_config_data, dict):
+                # New format: {"urls": [...], "refresh_interval_hours": 12, ...}
+                urls = remote_config_data.get("urls", [])
+                for entry in urls:
+                    remote_entries.append((entry, user_config_path))
+            else:
+                # Old format: direct list
+                for entry in remote_config_data:
+                    remote_entries.append((entry, user_config_path))
 
         # Load each remote config
         for entry, base_path in remote_entries:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -943,3 +943,213 @@ class TestSetupHooks:
             # Check that the correct path was shown in output
             captured = capsys.readouterr()
             assert str(custom_dir / 'settings.json') in captured.out
+
+
+class TestCreateDefaultConfig:
+    """Test cases for create_default_config functionality."""
+
+    def test_create_default_config_success(self, tmp_path):
+        """Test creating default config successfully."""
+        from ai_guardian.setup import create_default_config
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success, message = create_default_config(permissive=False, dry_run=False)
+
+            assert success is True
+            assert '✓ Created default config' in message
+            assert 'Secret scanning: Enabled' in message
+            assert 'Prompt injection: Enabled' in message
+            assert 'Permissions: Enabled' in message
+            assert config_file.exists()
+
+            # Verify config content
+            with open(config_file) as f:
+                config = json.load(f)
+
+            assert 'secret_scanning' in config
+            assert config['secret_scanning']['enabled'] is True
+            assert 'prompt_injection' in config
+            assert config['prompt_injection']['enabled'] is True
+            assert 'permissions' in config
+            assert config['permissions']['enabled'] is True
+            assert len(config['permissions']['rules']) == 2  # Skill and MCP deny rules
+
+    def test_create_default_config_permissive(self, tmp_path):
+        """Test creating permissive config."""
+        from ai_guardian.setup import create_default_config
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success, message = create_default_config(permissive=True, dry_run=False)
+
+            assert success is True
+            assert '✓ Created default config' in message
+            assert 'Permissions: Disabled' in message
+            assert config_file.exists()
+
+            # Verify config content
+            with open(config_file) as f:
+                config = json.load(f)
+
+            assert config['permissions']['enabled'] is False
+            assert len(config['permissions']['rules']) == 0  # No deny rules in permissive mode
+
+    def test_create_default_config_already_exists(self, tmp_path):
+        """Test creating config when file already exists."""
+        from ai_guardian.setup import create_default_config
+
+        config_file = tmp_path / 'ai-guardian.json'
+        config_file.write_text('{"existing": "config"}')
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success, message = create_default_config(permissive=False, dry_run=False)
+
+            assert success is False
+            assert 'already exists' in message
+
+    def test_create_default_config_dry_run(self, tmp_path):
+        """Test dry-run mode for config creation."""
+        from ai_guardian.setup import create_default_config
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success, message = create_default_config(permissive=False, dry_run=True)
+
+            assert success is True
+            assert '[DRY RUN]' in message
+            assert 'Would create' in message
+            assert not config_file.exists()  # File should not be created
+
+            # Verify JSON is in the message
+            assert '"secret_scanning"' in message
+            assert '"prompt_injection"' in message
+            assert '"permissions"' in message
+
+    def test_create_default_config_dry_run_permissive(self, tmp_path):
+        """Test dry-run mode with permissive config."""
+        from ai_guardian.setup import create_default_config
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success, message = create_default_config(permissive=True, dry_run=True)
+
+            assert success is True
+            assert '[DRY RUN]' in message
+            assert not config_file.exists()
+
+            # Verify permissive settings in dry-run output
+            assert '"enabled": false' in message or '"enabled":false' in message  # permissions disabled
+
+    def test_setup_hooks_with_create_config(self, tmp_path):
+        """Test setup with --create-config flag."""
+        from ai_guardian.setup import setup_hooks
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success = setup_hooks(
+                ide_type=None,
+                create_config=True,
+                permissive=False,
+                dry_run=False,
+                interactive=False
+            )
+
+            assert success is True
+            assert config_file.exists()
+
+    def test_setup_hooks_with_create_config_and_ide(self, tmp_path):
+        """Test setup with both --create-config and IDE setup."""
+        from ai_guardian.setup import setup_hooks
+
+        config_file = tmp_path / 'ai-guardian.json'
+        ide_config_file = tmp_path / 'settings.json'
+
+        with mock.patch('ai_guardian.setup.IDESetup') as MockSetup:
+            mock_instance = MockSetup.return_value
+            mock_instance.list_detected_ides.return_value = ['claude']
+            mock_instance.IDE_CONFIGS = {
+                'claude': {'name': 'Claude Code', 'config_path': str(ide_config_file)}
+            }
+            mock_instance.setup_ide_hooks.return_value = (True, 'Success')
+
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+                success = setup_hooks(
+                    ide_type='claude',
+                    create_config=True,
+                    permissive=False,
+                    dry_run=False,
+                    interactive=False
+                )
+
+                assert success is True
+                assert config_file.exists()
+                mock_instance.setup_ide_hooks.assert_called_once()
+
+    def test_setup_hooks_create_config_only(self, tmp_path):
+        """Test setup with only --create-config (no IDE or remote config)."""
+        from ai_guardian.setup import setup_hooks
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success = setup_hooks(
+                ide_type=None,
+                remote_config_url=None,
+                create_config=True,
+                permissive=False,
+                dry_run=False,
+                interactive=False
+            )
+
+            assert success is True
+            assert config_file.exists()
+
+    def test_get_default_config_template_secure(self):
+        """Test _get_default_config_template returns secure config by default."""
+        from ai_guardian.setup import _get_default_config_template
+
+        config = _get_default_config_template(permissive=False)
+
+        assert config['secret_scanning']['enabled'] is True
+        assert config['prompt_injection']['enabled'] is True
+        assert config['permissions']['enabled'] is True
+        assert len(config['permissions']['rules']) == 2
+        assert config['permissions']['rules'][0]['matcher'] == 'Skill'
+        assert config['permissions']['rules'][0]['mode'] == 'deny'
+        assert config['permissions']['rules'][1]['matcher'] == 'mcp__*'
+        assert config['permissions']['rules'][1]['mode'] == 'deny'
+
+    def test_get_default_config_template_permissive(self):
+        """Test _get_default_config_template returns permissive config."""
+        from ai_guardian.setup import _get_default_config_template
+
+        config = _get_default_config_template(permissive=True)
+
+        assert config['secret_scanning']['enabled'] is True
+        assert config['prompt_injection']['enabled'] is True
+        assert config['permissions']['enabled'] is False
+        assert len(config['permissions']['rules']) == 0
+
+    def test_create_default_config_with_schema(self, tmp_path):
+        """Test that default config includes schema reference."""
+        from ai_guardian.setup import create_default_config
+
+        config_file = tmp_path / 'ai-guardian.json'
+
+        with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': str(tmp_path)}):
+            success, message = create_default_config(permissive=False, dry_run=False)
+
+            assert success is True
+
+            # Verify schema is included
+            with open(config_file) as f:
+                config = json.load(f)
+
+            assert '$schema' in config
+            assert 'ai-guardian-config.schema.json' in config['$schema']


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.
GitHub Issue: https://github.com/itdove/ai-guardian/issues/178

## Description
This PR enhances the `ai-guardian setup` command to automatically create a default configuration file with explanatory comments, making it easier for users to get started with ai-guardian.

The changes include:
- Added default config creation functionality to the `ai-guardian setup` command
- Created a comprehensive config template with inline explanatory comments to guide users
- Fixed handling of `remote_configs` when specified in dict format with `urls` key
- Removed `directory_rules` and `code-review/security-review` from the default template to simplify the initial configuration
- Added unit tests to verify the setup command creates the default config correctly
- Updated CHANGELOG.md to document the new feature

This improvement reduces the barrier to entry for new users by providing them with a working configuration template that includes documentation about each setting.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Ensure you don't have an existing ai-guardian config file (or back it up)
3. Run `ai-guardian setup` command
4. Verify that a default configuration file is created in the expected location
5. Open the generated config file and verify it contains explanatory comments
6. Verify that `directory_rules`, `code-review`, and `security-review` are not present in the default template
7. Test that configurations with `remote_configs` using the dict format with `urls` key are handled correctly
8. Run the test suite: `pytest tests/test_setup.py`
9. Verify all tests pass

### Scenarios tested
- Running `ai-guardian setup` command to create a new default config file
- Verifying the generated config file contains proper structure and explanatory comments
- Running unit tests for the setup functionality to ensure proper config creation
- Validating that remote_configs with dict format (urls key) are properly handled

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: