### PR TITLE
itdove/ai-guardian#187: TypeError in Agent output secret scanning: write() expects str, not list

### DIFF
--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -1708,11 +1708,19 @@ def check_secrets_with_gitleaks(content, filename="temp_file", context: Optional
                     logging.info(f"Skipping secret scanning for ignored file: {file_path}")
                     return False, None
 
+        # Convert content to string if it's not already
+        # Agent tool outputs can be lists, dicts, or other types
+        if isinstance(content, list):
+            content = '\n'.join(str(item) for item in content)
+        elif not isinstance(content, str):
+            content = str(content)
+
         # Skip scanning if content appears to be a gitleaks config file
         # This prevents false positives when viewing pattern files
         if _is_gitleaks_config_content(content):
             logging.debug("Skipping scan - content appears to be a gitleaks config file")
             return False, None
+
         # Use in-memory filesystem on Linux for better performance
         tmp_base_dir = "/dev/shm" if os.path.exists("/dev/shm") else None
 

--- a/tests/test_ai_guardian.py
+++ b/tests/test_ai_guardian.py
@@ -27,6 +27,52 @@ class AIGuardianTest(TestCase):
         self.assertIsNone(error_msg, "No error message should be returned for clean content")
 
     @patch('ai_guardian._load_pattern_server_config')
+    def test_check_secrets_with_list_content(self, mock_pattern_config):
+        """Test that list content is handled correctly (Issue #187)"""
+        # Disable pattern server to use default gitleaks rules
+        mock_pattern_config.return_value = None
+
+        # Agent tool can return list output - should be converted to string
+        list_content = ["line 1", "line 2", "line 3"]
+        has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(
+            list_content, "test.txt"
+        )
+
+        self.assertFalse(has_secrets, "Clean list content should not be flagged as secret")
+        self.assertIsNone(error_msg, "No error message should be returned for clean content")
+
+    @patch('ai_guardian._load_pattern_server_config')
+    def test_check_secrets_with_list_containing_secret(self, mock_pattern_config):
+        """Test that secrets in list content are detected (Issue #187)"""
+        # Disable pattern server to use default gitleaks rules
+        mock_pattern_config.return_value = None
+
+        # Agent tool returns list with a secret in it
+        list_with_secret = ["normal text", "My token: ghp_16C0123456789abcdefghijklmTEST0000", "more text"]
+        has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(
+            list_with_secret, "test.txt"
+        )
+
+        self.assertTrue(has_secrets, "Secret in list should be detected")
+        self.assertIsNotNone(error_msg, "Error message should be returned for secrets")
+        self.assertIn("SECRET DETECTED", error_msg, "Error message should mention secret detection")
+
+    @patch('ai_guardian._load_pattern_server_config')
+    def test_check_secrets_with_dict_content(self, mock_pattern_config):
+        """Test that dict content is handled correctly (Issue #187)"""
+        # Disable pattern server to use default gitleaks rules
+        mock_pattern_config.return_value = None
+
+        # Agent tool could return dict output
+        dict_content = {"key": "value", "status": "success"}
+        has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(
+            dict_content, "test.txt"
+        )
+
+        self.assertFalse(has_secrets, "Clean dict content should not be flagged as secret")
+        self.assertIsNone(error_msg, "No error message should be returned for clean content")
+
+    @patch('ai_guardian._load_pattern_server_config')
     def test_check_secrets_with_github_token(self, mock_pattern_config):
         """Test that GitHub tokens are detected"""
         # Disable pattern server to use default gitleaks rules


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://redhat.atlassian.net//browse/itdove/ai-guardian#187>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This PR fixes a TypeError that occurred in the Agent output secret scanning functionality. The issue manifested when the `write()` method received a list instead of the expected string type, causing the scanning process to fail.

**Changes:**
- Updated secret scanning logic in `src/ai_guardian/__init__.py` to properly handle non-string content types (particularly lists)
- Added test coverage in `tests/test_ai_guardian.py` to verify correct handling of various content types during secret scanning

**Technical details:**
The root cause was that Agent output could contain list-type content which was being passed directly to a write operation expecting strings. The fix implements proper type checking and conversion to ensure all content is appropriately formatted before being written.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the test suite: `pytest tests/test_ai_guardian.py`
3. Execute secret scanning on Agent output that contains list-type content
4. Verify that no TypeError is raised during the scanning process
5. Confirm that secrets are still properly detected and reported

### Scenarios tested
- Secret scanning with Agent output containing list-type content (previously failing scenario)
- Secret scanning with standard string content (regression test)
- Mixed content types in Agent output
- All existing test cases pass with the fix applied

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: