### PR TITLE
Fix missing violation log types for secret redaction (issue #211)

### DIFF
--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -2388,14 +2388,18 @@ def process_hook_input():
                         # Log to violation logger
                         from ai_guardian.violation_logger import ViolationLogger
                         violation_logger = ViolationLogger()
-                        violation_logger.log({
-                            'type': 'secret_redaction',
-                            'tool': tool_identifier,
-                            'redaction_count': len(redactions),
-                            'redacted_types': [r['type'] for r in redactions],
-                            'action': 'redacted',
-                            'mode': action
-                        })
+                        violation_logger.log_violation(
+                            violation_type='secret_redaction',
+                            blocked={
+                                'tool': tool_identifier,
+                                'redaction_count': len(redactions),
+                                'redacted_types': [r['type'] for r in redactions]
+                            },
+                            context={
+                                'action': 'redacted',
+                                'mode': action
+                            }
+                        )
 
                         # Return redacted output (allow, with modifications)
                         # For warn mode, include a warning message

--- a/src/ai_guardian/tui/secrets.py
+++ b/src/ai_guardian/tui/secrets.py
@@ -203,6 +203,7 @@ class SecretsContent(Container):
                     yield Checkbox("Tool Permission", id="log-type-tool", value=True)
                     yield Checkbox("Directory Blocking", id="log-type-directory", value=True)
                     yield Checkbox("Secret Detected", id="log-type-secret", value=True)
+                    yield Checkbox("Secret Redaction", id="log-type-redaction", value=True)
                     yield Checkbox("Prompt Injection", id="log-type-injection", value=True)
 
     def on_mount(self) -> None:
@@ -289,7 +290,7 @@ class SecretsContent(Container):
         log_enabled = violation_logging.get("enabled", True)
         max_entries = violation_logging.get("max_entries", 1000)
         retention_days = violation_logging.get("retention_days", 30)
-        log_types = violation_logging.get("log_types", ["tool_permission", "directory_blocking", "secret_detected", "prompt_injection"])
+        log_types = violation_logging.get("log_types", ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"])
 
         try:
             self.query_one("#violation-logging-enabled", Checkbox).value = log_enabled
@@ -300,6 +301,7 @@ class SecretsContent(Container):
             self.query_one("#log-type-tool", Checkbox).value = "tool_permission" in log_types
             self.query_one("#log-type-directory", Checkbox).value = "directory_blocking" in log_types
             self.query_one("#log-type-secret", Checkbox).value = "secret_detected" in log_types
+            self.query_one("#log-type-redaction", Checkbox).value = "secret_redaction" in log_types
             self.query_one("#log-type-injection", Checkbox).value = "prompt_injection" in log_types
         except Exception:
             pass  # Widgets may not be mounted yet
@@ -605,6 +607,8 @@ class SecretsContent(Container):
                 log_types.append("directory_blocking")
             if self.query_one("#log-type-secret", Checkbox).value:
                 log_types.append("secret_detected")
+            if self.query_one("#log-type-redaction", Checkbox).value:
+                log_types.append("secret_redaction")
             if self.query_one("#log-type-injection", Checkbox).value:
                 log_types.append("prompt_injection")
 

--- a/src/ai_guardian/tui/violations.py
+++ b/src/ai_guardian/tui/violations.py
@@ -217,6 +217,15 @@ class ViolationCard(Vertical):
             yield Static(f"Source: {source}", classes="violation-detail")
             yield Static(f"Pattern: {pattern}", classes="violation-detail")
 
+        elif vtype == "secret_redaction":
+            tool = blocked.get("tool", "Unknown")
+            redaction_count = blocked.get("redaction_count", 0)
+            redacted_types = blocked.get("redacted_types", [])
+            yield Static(f"Tool: {tool}", classes="violation-detail")
+            yield Static(f"Redacted: {redaction_count} secret(s)", classes="violation-detail")
+            if redacted_types:
+                yield Static(f"Types: {', '.join(redacted_types)}", classes="violation-detail")
+
         # Action buttons
         if not resolved:
             # Unresolved violations - show approve/deny buttons
@@ -321,6 +330,8 @@ class ViolationsContent(Container):
                 yield VerticalScroll(id="violations-list-tool")
             with TabPane("Secrets", id="filter-secret"):
                 yield VerticalScroll(id="violations-list-secret")
+            with TabPane("Secret Redaction", id="filter-redaction"):
+                yield VerticalScroll(id="violations-list-redaction")
             with TabPane("Directories", id="filter-directory"):
                 yield VerticalScroll(id="violations-list-directory")
             with TabPane("Prompt Injection", id="filter-injection"):
@@ -351,6 +362,12 @@ class ViolationsContent(Container):
             limit=50, violation_type="secret_detected", resolved=None
         )
         self._populate_list("#violations-list-secret", secret_violations)
+
+        # Load secret redaction violations
+        redaction_violations = self.violation_logger.get_recent_violations(
+            limit=50, violation_type="secret_redaction", resolved=None
+        )
+        self._populate_list("#violations-list-redaction", redaction_violations)
 
         # Load directory violations
         directory_violations = self.violation_logger.get_recent_violations(
@@ -449,6 +466,7 @@ class ViolationsContent(Container):
                 "filter-all": "#violations-list-all",
                 "filter-tool-permission": "#violations-list-tool",
                 "filter-secret": "#violations-list-secret",
+                "filter-redaction": "#violations-list-redaction",
                 "filter-directory": "#violations-list-directory",
                 "filter-injection": "#violations-list-injection"
             }
@@ -551,6 +569,14 @@ class ViolationsContent(Container):
         try:
             filter_tabs = self.query_one("#filter-tabs", TabbedContent)
             filter_tabs.active = "filter-injection"
+        except:
+            pass
+
+    def action_filter_redaction(self) -> None:
+        """Filter secret redaction violations (triggered by '6' key)."""
+        try:
+            filter_tabs = self.query_one("#filter-tabs", TabbedContent)
+            filter_tabs.active = "filter-redaction"
         except:
             pass
 

--- a/src/ai_guardian/violation_logger.py
+++ b/src/ai_guardian/violation_logger.py
@@ -331,7 +331,7 @@ class ViolationLogger:
             "enabled": True,
             "max_entries": 1000,
             "retention_days": 30,
-            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "prompt_injection"]
+            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
         }
 
     def _is_logging_enabled(self) -> bool:


### PR DESCRIPTION
## Description

Fixed critical bug in secret redaction logging and added missing `secret_redaction` violation log type for issue #211.

### Critical Bug Fixed
**File:** `src/ai_guardian/__init__.py` (lines 2391-2398)

The code was calling a non-existent `.log()` method instead of `.log_violation()`, which would cause crashes with `AttributeError` when secret redaction occurred.

**Before:**
```python
violation_logger.log({
    'type': 'secret_redaction',
    ...
})
```

**After:**
```python
violation_logger.log_violation(
    violation_type='secret_redaction',
    blocked={...},
    context={...}
)
```

### Missing Log Type Added
Added `secret_redaction` to the default log types in `violation_logger.py` to ensure redaction events are logged by default alongside other violation types (tool_permission, directory_blocking, secret_detected, prompt_injection).

### TUI Updates
1. **Violations Tab** - Added handling for `secret_redaction` violation type:
   - Display tool name, redaction count, and secret types
   - Added "Secret Redaction" filter tab
   - Added action handler for keyboard navigation

2. **Secrets Tab** - Added "Secret Redaction" checkbox:
   - Users can enable/disable logging of secret_redaction events
   - Integrated with existing log type filtering

### Verification
Verified that SSRF protection and config scanner do NOT log violations, so no additional log types needed for those features.

## Testing

### Steps to test
1. Pull down the PR
2. Run pytest with clean config: `AI_GUARDIAN_CONFIG_DIR=/tmp/test-config pytest`
3. Test secret redaction logging manually:
   - Enable secret_redaction in config with `action: "log-only"`
   - Trigger a Bash command that outputs a secret
   - Verify violation is logged to `~/.config/ai-guardian/violations.jsonl`
   - Open TUI and verify "Secret Redaction" tab shows the violation

### Scenarios tested
- [x] ViolationLogger.log_violation() method works correctly
- [x] secret_redaction appears in default log_types
- [x] TUI violations tab displays secret_redaction violations
- [x] TUI secrets tab has checkbox for secret_redaction
- [x] All violation logger tests pass (16/16)
- [x] All secret redaction tests pass (34/34)
- [x] No regressions in existing functionality

## Related Issues

Closes #211

Part of Hermes Security Patterns integration (issues #194-198):
- Issue #197: Secret Redaction (this PR fixes the logging bug)
- Issue #195: Unicode Attack Detection (covered by existing `prompt_injection` type)
- Issue #194: SSRF Protection (does not log violations)
- Issue #196: Config Scanner (does not log violations)
- Issue #198: Static Scanning/Integration (CI/CD only, no runtime violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>