### PR TITLE
fix: add missing violation_logging config section to setup.py and JSON schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Setup command now generates complete configuration with violation_logging section** (Issue #214)
+  - Fixed missing `violation_logging` section in `ai-guardian setup --create-config` output
+  - Added `violation_logging` property to JSON schema with proper validation
+  - Users can now discover and configure violation logging from generated config files
+  - Includes all log types: tool_permission, directory_blocking, secret_detected, secret_redaction, prompt_injection
+  - Improves discoverability of violation logging feature (available since v1.1.0)
 - **Overly aggressive self-protection heuristic no longer blocks legitimate content** (Issue #188)
   - Fixed false positives where commands mentioning "ai-guardian" in content were blocked
   - Self-protection patterns are now path-specific, only blocking when targeting actual protected files:

--- a/src/ai_guardian/schemas/ai-guardian-config.schema.json
+++ b/src/ai_guardian/schemas/ai-guardian-config.schema.json
@@ -806,6 +806,39 @@
           "default": []
         }
       }
+    },
+    "violation_logging": {
+      "type": "object",
+      "description": "Violation logging configuration (NEW in v1.1.0). Logs blocked operations to JSONL file for audit and review.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable violation logging",
+          "default": true
+        },
+        "max_entries": {
+          "type": "number",
+          "description": "Maximum number of log entries to retain",
+          "default": 1000,
+          "minimum": 1
+        },
+        "retention_days": {
+          "type": "number",
+          "description": "Number of days to retain log entries",
+          "default": 30,
+          "minimum": 1
+        },
+        "log_types": {
+          "type": "array",
+          "description": "Types of violations to log. Empty array logs all types.",
+          "items": {
+            "type": "string",
+            "enum": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+          },
+          "default": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+        }
+      },
+      "additionalProperties": false
     }
   },
   "definitions": {

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -904,6 +904,14 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
         "_comment_remote_configs": "Load additional policies from remote URLs (for enterprise/team policies)",
         "remote_configs": {
             "urls": []
+        },
+
+        "_comment_violation_logging": "Log blocked operations for audit and review (NEW in v1.1.0)",
+        "violation_logging": {
+            "enabled": True,
+            "max_entries": 1000,
+            "retention_days": 30,
+            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #214

The `setup.py` file was missing the creation of the `violation_logging` entry in the default ai-guardian.json configuration template. When users ran `ai-guardian setup --create-config`, the generated config file did not include the violation_logging section, even though this feature has been available since v1.1.0.

Additionally, the JSON schema file was also missing the `violation_logging` property definition.

### Changes Made

1. **JSON Schema** (`src/ai_guardian/schemas/ai-guardian-config.schema.json`)
   - Added `violation_logging` property definition with all required fields
   - Includes: `enabled`, `max_entries`, `retention_days`, `log_types`
   - Proper validation rules and defaults
   - Includes all log types: tool_permission, directory_blocking, secret_detected, secret_redaction, prompt_injection

2. **Setup.py** (`src/ai_guardian/setup.py`)
   - Added `violation_logging` section to `_get_default_config_template()` function
   - Matches defaults from `ViolationLogger._get_default_config()` (lines 328-335)
   - Includes comment field for documentation

3. **CHANGELOG.md**
   - Updated under `[Unreleased] > Fixed` section
   - Documents the fix and its impact

## Testing

### Verification Tests Passed

```
✅ Setup.py generates violation_logging config section
✅ JSON schema validates violation_logging properties  
✅ All log types included (including secret_redaction from #211)
```

### Test Command Output

```python
# Generated config now includes:
"_comment_violation_logging": "Log blocked operations for audit and review (NEW in v1.1.0)",
"violation_logging": {
    "enabled": True,
    "max_entries": 1000,
    "retention_days": 30,
    "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
}
```

### Steps to test

1. Pull down the PR
2. Delete existing config: `rm ~/.config/ai-guardian/ai-guardian.json`
3. Regenerate config: `ai-guardian setup --create-config`
4. Verify violation_logging section exists: `cat ~/.config/ai-guardian/ai-guardian.json | grep -A 7 violation_logging`
5. Verify JSON schema validation works
6. Run test suite: `pytest`

### Scenarios tested

- [x] Setup command generates complete config with violation_logging
- [x] JSON schema validates violation_logging section
- [x] All log types present including secret_redaction
- [x] Config values match ViolationLogger defaults
- [x] Existing test suite passes (986 passed, 1 pre-existing failure)
- [x] TUI already handles missing section gracefully (no changes needed)

## Impact

**Before Fix:**
- Users running `ai-guardian setup --create-config` got incomplete configs
- Violation logging functionality not discoverable in fresh installations
- Users had to manually add section to configure violation logging

**After Fix:**
- Complete configuration files generated out of the box
- Violation logging feature fully discoverable
- Consistent with other security features (secret_scanning, prompt_injection, etc.)
- TUI violation log configuration works immediately

## References

- Issue #214
- Related: Issue #211 (added secret_redaction log type)
- ViolationLogger implementation: `src/ai_guardian/violation_logger.py:322-335`
- TUI usage: `src/ai_guardian/tui/secrets.py:296-300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>