### PR TITLE
fix: add missing permissions_directories to setup.py default config template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Setup.py Missing permissions_directories in Default Config Template** (Issue #240)
+  - **Fix**: Added `permissions_directories` field to `_get_default_config_template()` function in setup.py
+  - **Problem**: Users running `ai-guardian setup --create-config` got incomplete configuration files missing the `permissions_directories` option
+  - **Root Cause**: When `permissions_directories` was added to the schema, setup.py wasn't updated (violating AGENTS.md configuration consistency guidelines)
+  - **Impact**: Generated configs now include `permissions_directories` with comprehensive comments and examples:
+    - Local directory scanning example (`~/.claude/skills`)
+    - GitHub repository scanning example with token_env
+    - Documentation explaining it's OPTIONAL/ADVANCED and most users should prefer remote_configs
+  - **Location**: Added to setup.py after permissions section (line 893), before directory_rules
+  - **Verification**: Tested via `_get_default_config_template()` and confirmed field appears in generated config
+
 - **JSON Schema Missing Definitions** (Issue #239)
   - **Fix**: Added missing `pattern_server_auth` and `pattern_server_cache` definitions to schema
   - **Problem**: Schema referenced definitions that didn't exist, causing validation failures for pattern_server configurations

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -890,6 +890,23 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             ]
         },
 
+        "_comment_permissions_directories": "OPTIONAL/ADVANCED: Auto-discover tool permissions from directories/GitHub repos. Scans for permission files and merges discovered rules into permissions.rules. Most users should use remote_configs instead.",
+        "_permissions_directories_example": [
+            {
+                "_comment": "Example: scan local skills directory to auto-allow discovered skills",
+                "matcher": "Skill",
+                "mode": "allow",
+                "url": "~/.claude/skills"
+            },
+            {
+                "_comment": "Example: scan GitHub repository for skills",
+                "matcher": "Skill",
+                "mode": "allow",
+                "url": "https://github.com/your-org/skills/tree/main/skills",
+                "token_env": "GITHUB_TOKEN"
+            }
+        ],
+
         "_comment_directory_rules": "OPTIONAL: Control AI access to specific directories (e.g., block ~/.ssh). See ai-guardian-example.json for examples.",
         "_directory_rules_example": {
             "action": "block",


### PR DESCRIPTION
## Description

Fixes #240 - Adds the missing `permissions_directories` configuration field to setup.py's default config template.

### Problem

The `permissions_directories` configuration option was:
- ✅ Defined in schema (lines 40-71)
- ✅ Fully implemented in code (tool_policy.py)
- ✅ Has TUI support (tui/permissions_discovery.py)
- ✅ Documented in ai-guardian-example.json
- ❌ **MISSING from setup.py** `_get_default_config_template()` function

This violated the project's configuration consistency guidelines from AGENTS.md which requires all schema fields to be included in the default config template.

### Impact

Users running `ai-guardian setup --create-config` were getting incomplete configuration files. The feature existed and worked correctly, but wasn't discoverable in generated configs.

### Solution

Added `permissions_directories` field to setup.py's `_get_default_config_template()` function (after permissions section, line 893) with:
- Comprehensive comment explaining it's OPTIONAL/ADVANCED
- Two examples: 
  - Local directory scanning (`~/.claude/skills`)
  - GitHub repository scanning with token_env
- Documentation that most users should prefer `remote_configs` instead

### Files Changed

- `src/ai_guardian/setup.py` - Added permissions_directories field to default config template
- `CHANGELOG.md` - Documented the fix under [Unreleased] > Fixed

## Testing

### Verification Steps

1. ✅ Tested via `_get_default_config_template()` function - confirmed field is present
2. ✅ All 1117 tests pass (0 failures, 6 skipped, 1 warning)
3. ✅ Generated config includes the new field with proper formatting

### Manual Testing

```bash
# Verify field is in template
python -c "from src.ai_guardian.setup import _get_default_config_template; import json; config = _get_default_config_template(); print(json.dumps(config.get('_permissions_directories_example'), indent=2))"
```

Output shows:
```json
[
  {
    "_comment": "Example: scan local skills directory to auto-allow discovered skills",
    "matcher": "Skill",
    "mode": "allow",
    "url": "~/.claude/skills"
  },
  {
    "_comment": "Example: scan GitHub repository for skills",
    "matcher": "Skill",
    "mode": "allow",
    "url": "https://github.com/your-org/skills/tree/main/skills",
    "token_env": "GITHUB_TOKEN"
  }
]
```

### Test Results

```
======== 1117 passed, 6 skipped, 1 warning in 4.62s =========
```

All tests pass successfully. No regressions detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>