### PR TITLE
Enhancement: Skip scanner installation if already up-to-date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scanner Installer: Skip Installation if Already Up-to-Date** (Issue #271)
+  - **Smart Version Checking**: `ai-guardian scanner install` now checks if scanner is already installed before downloading
+  - **Skip When Up-to-Date**: Automatically skips installation if the latest version is already installed
+  - **Upgrade Detection**: Automatically upgrades when a newer version is available
+  - **Downgrade Protection**: Does not auto-downgrade without explicit `--version` flag
+  - **Explicit Control**: `--version` flag allows downgrade or reinstall of specific versions
+  - **Clear Messaging**: Shows current version, target version, and action taken
+  - **Version Comparison**: Proper semantic version comparison (e.g., 8.30.1 < 8.31.0)
+  - **Performance**: Saves bandwidth and time by skipping unnecessary downloads
+  - **Implementation**:
+    - Added `_get_installed_version()` method to detect currently installed version
+    - Added `_compare_versions()` method for semantic version comparison
+    - Updated `install()` method with version checking logic
+  - **Test Coverage**: Added 10 comprehensive test cases for version checking scenarios
+  - **Benefits**: Faster installation, bandwidth-friendly, safe (no auto-downgrades), clear user feedback
+
 - **SSRF Protection: Wildcard Domain Pattern Support** (Issue #253)
   - **New Feature**: Added wildcard pattern matching for `additional_blocked_domains` configuration
   - **Syntax**: Supports `*` (match zero or more characters) and `?` (match exactly one character)

--- a/src/ai_guardian/scanner_installer.py
+++ b/src/ai_guardian/scanner_installer.py
@@ -417,6 +417,49 @@ class ScannerInstaller:
             target_version = self.get_latest_version(scanner_name)
             logger.info(f"Installing {scanner_name} {target_version}")
 
+        # Check if already installed
+        installed_version = self._get_installed_version(scanner_name)
+
+        if installed_version:
+            comparison = self._compare_versions(installed_version, target_version)
+
+            if comparison == 0 and not version:
+                # Already up-to-date, skip installation
+                binary_path = shutil.which(scanner_name)
+                if not binary_path:
+                    binary_path = self.install_dir / scanner_name
+                print(f"✓ {scanner_name} {installed_version} is already installed (up-to-date)")
+                print(f"  Path: {binary_path}")
+                print()
+                print("No action needed.")
+                return True
+            elif comparison < 0:
+                # Installed version is older, upgrade available
+                print(f"Current version: {installed_version}")
+                print(f"Latest version:  {target_version}")
+                print()
+                print(f"Upgrading {scanner_name} from {installed_version} to {target_version}...")
+            elif comparison > 0 and not version:
+                # Installed version is newer, don't auto-downgrade
+                binary_path = shutil.which(scanner_name)
+                if not binary_path:
+                    binary_path = self.install_dir / scanner_name
+                print(f"✓ {scanner_name} {installed_version} is already installed")
+                print(f"  Path: {binary_path}")
+                print()
+                print(f"Latest version available: {target_version}")
+                print(f"To downgrade, use: ai-guardian scanner install {scanner_name} --version {target_version}")
+                return True
+            else:
+                # Explicit version specified: allow downgrade/reinstall
+                if comparison == 0:
+                    action = "Reinstalling"
+                elif comparison > 0:
+                    action = "Downgrading"
+                else:
+                    action = "Upgrading"
+                print(f"{action} {scanner_name} to {target_version}...")
+
         # Try package manager first (unless method specified)
         if method is None or method == InstallMethod.PACKAGE_MANAGER:
             if self.install_via_package_manager(scanner_name):
@@ -433,6 +476,88 @@ class ScannerInstaller:
                 return False
 
         return False
+
+    def _get_installed_version(self, scanner_name: str) -> Optional[str]:
+        """
+        Get the currently installed version of a scanner.
+
+        Args:
+            scanner_name: Scanner to check
+
+        Returns:
+            Version string (without 'v' prefix) if installed, None otherwise
+        """
+        binary_path = shutil.which(scanner_name)
+        if not binary_path:
+            # Check in install_dir
+            binary_path = self.install_dir / scanner_name
+            if not binary_path.exists():
+                return None
+            binary_path = str(binary_path)
+
+        # Try to get version
+        try:
+            result = subprocess.run(
+                [binary_path, "version"],
+                capture_output=True,
+                timeout=5,
+                text=True,
+            )
+            if result.returncode == 0:
+                # Parse version from output
+                # Expected formats:
+                # - "gitleaks version 8.30.1"
+                # - "8.30.1"
+                # - "v8.30.1"
+                output = result.stdout.strip()
+
+                # Extract version number
+                import re
+                # Match semantic version pattern
+                match = re.search(r'v?(\d+\.\d+\.\d+)', output)
+                if match:
+                    return match.group(1)
+
+                logger.debug(f"Could not parse version from output: {output}")
+                return None
+        except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+            logger.debug(f"Failed to get version for {scanner_name}: {e}")
+            return None
+
+        return None
+
+    def _compare_versions(self, version1: str, version2: str) -> int:
+        """
+        Compare two semantic versions.
+
+        Args:
+            version1: First version string (e.g., "8.30.1")
+            version2: Second version string (e.g., "8.31.0")
+
+        Returns:
+            -1 if version1 < version2
+             0 if version1 == version2
+             1 if version1 > version2
+        """
+        # Parse version strings
+        def parse_version(v: str) -> tuple:
+            parts = v.strip().lstrip('v').split('.')
+            return tuple(int(p) for p in parts)
+
+        try:
+            v1_parts = parse_version(version1)
+            v2_parts = parse_version(version2)
+
+            if v1_parts < v2_parts:
+                return -1
+            elif v1_parts > v2_parts:
+                return 1
+            else:
+                return 0
+        except (ValueError, AttributeError) as e:
+            logger.warning(f"Failed to compare versions {version1} and {version2}: {e}")
+            # If parsing fails, treat as equal (no upgrade/downgrade)
+            return 0
 
     def verify_installation(self, scanner_name: str) -> bool:
         """

--- a/tests/test_scanner_installer.py
+++ b/tests/test_scanner_installer.py
@@ -131,17 +131,19 @@ class TestScannerInstaller:
         with pytest.raises(ValueError, match="Unsupported scanner"):
             installer.install("invalid_scanner")
 
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
     @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_latest_version")
     @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.install_from_download")
     @mock.patch(
         "ai_guardian.scanner_installer.ScannerInstaller.install_via_package_manager"
     )
     def test_install_with_explicit_version(
-        self, mock_pkg_mgr, mock_download, mock_get_latest
+        self, mock_pkg_mgr, mock_download, mock_get_latest, mock_get_installed
     ):
         """Test installation with explicit version flag."""
         mock_pkg_mgr.return_value = False  # Package manager fails
         mock_download.return_value = Path("/fake/path/gitleaks")
+        mock_get_installed.return_value = None  # Not installed
 
         installer = ScannerInstaller()
         success = installer.install("gitleaks", version="8.30.1")
@@ -151,6 +153,7 @@ class TestScannerInstaller:
         mock_download.assert_called_once_with("gitleaks", "8.30.1")
         assert success
 
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
     @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_latest_version")
     @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_pinned_version")
     @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.install_from_download")
@@ -158,12 +161,13 @@ class TestScannerInstaller:
         "ai_guardian.scanner_installer.ScannerInstaller.install_via_package_manager"
     )
     def test_install_with_use_pinned(
-        self, mock_pkg_mgr, mock_download, mock_get_pinned, mock_get_latest
+        self, mock_pkg_mgr, mock_download, mock_get_pinned, mock_get_latest, mock_get_installed
     ):
         """Test installation with use_pinned flag."""
         mock_pkg_mgr.return_value = False  # Package manager fails
         mock_download.return_value = Path("/fake/path/gitleaks")
         mock_get_pinned.return_value = "8.29.0"
+        mock_get_installed.return_value = None  # Not installed
 
         installer = ScannerInstaller()
         success = installer.install("gitleaks", use_pinned=True)
@@ -283,3 +287,196 @@ class TestPlatformDetection:
 
         installer = ScannerInstaller()
         assert installer.detect_platform() == "linux_arm64"
+
+
+class TestVersionChecking:
+    """Tests for version checking and smart installation."""
+
+    @mock.patch("shutil.which")
+    @mock.patch("subprocess.run")
+    def test_get_installed_version(self, mock_run, mock_which):
+        """Test getting installed version of a scanner."""
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+        mock_run.return_value = mock.Mock(
+            returncode=0,
+            stdout="gitleaks version 8.30.1\n"
+        )
+
+        installer = ScannerInstaller()
+        version = installer._get_installed_version("gitleaks")
+
+        assert version == "8.30.1"
+
+    @mock.patch("shutil.which")
+    @mock.patch("subprocess.run")
+    def test_get_installed_version_with_v_prefix(self, mock_run, mock_which):
+        """Test parsing version with 'v' prefix."""
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+        mock_run.return_value = mock.Mock(
+            returncode=0,
+            stdout="v8.30.1\n"
+        )
+
+        installer = ScannerInstaller()
+        version = installer._get_installed_version("gitleaks")
+
+        assert version == "8.30.1"
+
+    @mock.patch("shutil.which")
+    def test_get_installed_version_not_installed(self, mock_which):
+        """Test getting version when scanner not installed."""
+        mock_which.return_value = None
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            installer = ScannerInstaller(install_dir=Path(temp_dir))
+            version = installer._get_installed_version("gitleaks")
+
+            assert version is None
+
+    def test_compare_versions_less_than(self):
+        """Test version comparison: v1 < v2."""
+        installer = ScannerInstaller()
+
+        assert installer._compare_versions("8.30.1", "8.31.0") == -1
+        assert installer._compare_versions("8.30.1", "9.0.0") == -1
+        assert installer._compare_versions("8.30.0", "8.30.1") == -1
+
+    def test_compare_versions_equal(self):
+        """Test version comparison: v1 == v2."""
+        installer = ScannerInstaller()
+
+        assert installer._compare_versions("8.30.1", "8.30.1") == 0
+        assert installer._compare_versions("v8.30.1", "8.30.1") == 0
+
+    def test_compare_versions_greater_than(self):
+        """Test version comparison: v1 > v2."""
+        installer = ScannerInstaller()
+
+        assert installer._compare_versions("8.31.0", "8.30.1") == 1
+        assert installer._compare_versions("9.0.0", "8.30.1") == 1
+        assert installer._compare_versions("8.30.1", "8.30.0") == 1
+
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_latest_version")
+    @mock.patch("shutil.which")
+    def test_install_skip_when_up_to_date(
+        self, mock_which, mock_get_latest, mock_get_installed
+    ):
+        """Test that installation is skipped when already up-to-date."""
+        mock_get_installed.return_value = "8.30.1"
+        mock_get_latest.return_value = "8.30.1"
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+
+        installer = ScannerInstaller()
+        success = installer.install("gitleaks")
+
+        # Should skip installation
+        assert success
+        mock_get_installed.assert_called_once_with("gitleaks")
+
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_latest_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.install_from_download")
+    @mock.patch(
+        "ai_guardian.scanner_installer.ScannerInstaller.install_via_package_manager"
+    )
+    @mock.patch("shutil.which")
+    def test_install_upgrade_when_newer_available(
+        self, mock_which, mock_pkg_mgr, mock_download, mock_get_latest, mock_get_installed
+    ):
+        """Test that installation proceeds when upgrade is available."""
+        mock_get_installed.return_value = "8.30.1"
+        mock_get_latest.return_value = "8.31.0"
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+        mock_pkg_mgr.return_value = False
+        mock_download.return_value = Path("/fake/path/gitleaks")
+
+        installer = ScannerInstaller()
+        success = installer.install("gitleaks")
+
+        # Should proceed with upgrade
+        assert success
+        mock_download.assert_called_once_with("gitleaks", "8.31.0")
+
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_latest_version")
+    @mock.patch("shutil.which")
+    def test_install_no_auto_downgrade(
+        self, mock_which, mock_get_latest, mock_get_installed
+    ):
+        """Test that auto-downgrade is prevented without explicit version."""
+        mock_get_installed.return_value = "8.31.0"
+        mock_get_latest.return_value = "8.30.1"
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+
+        installer = ScannerInstaller()
+        success = installer.install("gitleaks")
+
+        # Should skip downgrade and return True
+        assert success
+
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.install_from_download")
+    @mock.patch(
+        "ai_guardian.scanner_installer.ScannerInstaller.install_via_package_manager"
+    )
+    @mock.patch("shutil.which")
+    def test_install_explicit_downgrade_allowed(
+        self, mock_which, mock_pkg_mgr, mock_download, mock_get_installed
+    ):
+        """Test that explicit version allows downgrade."""
+        mock_get_installed.return_value = "8.31.0"
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+        mock_pkg_mgr.return_value = False
+        mock_download.return_value = Path("/fake/path/gitleaks")
+
+        installer = ScannerInstaller()
+        success = installer.install("gitleaks", version="8.30.1")
+
+        # Should proceed with downgrade
+        assert success
+        mock_download.assert_called_once_with("gitleaks", "8.30.1")
+
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.install_from_download")
+    @mock.patch(
+        "ai_guardian.scanner_installer.ScannerInstaller.install_via_package_manager"
+    )
+    @mock.patch("shutil.which")
+    def test_install_explicit_reinstall_allowed(
+        self, mock_which, mock_pkg_mgr, mock_download, mock_get_installed
+    ):
+        """Test that explicit version allows reinstalling same version."""
+        mock_get_installed.return_value = "8.30.1"
+        mock_which.return_value = "/usr/local/bin/gitleaks"
+        mock_pkg_mgr.return_value = False
+        mock_download.return_value = Path("/fake/path/gitleaks")
+
+        installer = ScannerInstaller()
+        success = installer.install("gitleaks", version="8.30.1")
+
+        # Should proceed with reinstall
+        assert success
+        mock_download.assert_called_once_with("gitleaks", "8.30.1")
+
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller._get_installed_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.get_latest_version")
+    @mock.patch("ai_guardian.scanner_installer.ScannerInstaller.install_from_download")
+    @mock.patch(
+        "ai_guardian.scanner_installer.ScannerInstaller.install_via_package_manager"
+    )
+    def test_install_when_not_installed(
+        self, mock_pkg_mgr, mock_download, mock_get_latest, mock_get_installed
+    ):
+        """Test normal installation when scanner not already installed."""
+        mock_get_installed.return_value = None
+        mock_get_latest.return_value = "8.30.1"
+        mock_pkg_mgr.return_value = False
+        mock_download.return_value = Path("/fake/path/gitleaks")
+
+        installer = ScannerInstaller()
+        success = installer.install("gitleaks")
+
+        # Should proceed with installation
+        assert success
+        mock_download.assert_called_once_with("gitleaks", "8.30.1")


### PR DESCRIPTION
## Description

Closes #271

Implemented smart version checking for scanner installation to avoid unnecessary downloads and improve user experience.

The `ai-guardian scanner install` command now:
- Checks if the scanner is already installed before downloading
- Skips installation if the latest version is already installed
- Automatically upgrades when a newer version is available
- Does not auto-downgrade without explicit `--version` flag
- Allows explicit downgrade/reinstall with `--version` flag
- Shows clear messages about current version, target version, and action taken

## Changes

### Added
- `_get_installed_version()` method to detect currently installed version
- `_compare_versions()` method for semantic version comparison
- Version checking logic in `install()` method

### Modified
- `src/ai_guardian/scanner_installer.py` - Added version checking and comparison
- `tests/test_scanner_installer.py` - Added 10 comprehensive test cases
- `CHANGELOG.md` - Documented new feature

## Testing

### Steps to test
1. Pull down the PR
2. Install a scanner: `ai-guardian scanner install gitleaks`
3. Run install again: `ai-guardian scanner install gitleaks`
4. Verify it shows "already installed (up-to-date)" message and skips download

### Scenarios tested
- ✅ Skip if already up-to-date (no `--version` flag)
- ✅ Upgrade if newer version available
- ✅ Do NOT auto-downgrade without `--version` flag
- ✅ `--version` allows downgrade/reinstall
- ✅ Clear messages showing action and reason
- ✅ Version comparison works (8.30.1 < 8.31.0)
- ✅ Parse version with/without 'v' prefix
- ✅ Handle scanner not installed
- ✅ All existing tests still pass (1190 passed)

## Benefits

✅ Faster (skip unnecessary downloads)
✅ Bandwidth-friendly
✅ Safe (no auto-downgrades)
✅ Clear user feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>