### PR TITLE
itdove/ai-guardian#290: Add scanner version existence check to prevent broken downloads

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,31 @@ on:
       - '.github/workflows/integration-tests.yml'
 
 jobs:
+  version-check:
+    name: Verify Scanner Versions Exist
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install requests
+
+      - name: Check scanner versions exist
+        run: |
+          python scripts/check_scanner_versions.py
+
   integration-tests:
     name: Run Integration Tests
     runs-on: ubuntu-latest
+    needs: version-check
 
     steps:
       - name: Checkout code
@@ -102,6 +124,7 @@ jobs:
   test-isolation:
     name: Test Isolation Verification
     runs-on: ubuntu-latest
+    needs: version-check
 
     steps:
       - name: Checkout code
@@ -144,6 +167,7 @@ jobs:
   performance-check:
     name: Performance Check
     runs-on: ubuntu-latest
+    needs: version-check
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,31 @@ on:
       - main
 
 jobs:
+  version-check:
+    name: Verify Scanner Versions Exist
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install requests
+
+      - name: Check scanner versions exist
+        run: |
+          python scripts/check_scanner_versions.py
+
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    needs: version-check
 
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scanner Version Existence Check** (Issue #290)
+  - **Pre-flight Check Script**: `scripts/check_scanner_versions.py`
+    - Verifies pinned scanner versions in `pyproject.toml` exist on GitHub releases
+    - Checks download URLs are accessible via GitHub Releases API
+    - Prevents CI failures from yanked versions, deleted repos, or missing assets
+    - Reports file sizes and download URLs for each scanner
+    - Exits with code 1 if any version is missing (fails workflow fast)
+    - Supports different asset naming conventions:
+      - gitleaks/betterleaks: `scanner_version_platform.tar.gz`
+      - leaktk: `scanner-version-platform.tar.xz` with hyphens and x86_64
+  - **CI/CD Integration**: Added to workflows
+    - `.github/workflows/integration-tests.yml`: New `version-check` job runs before all test jobs
+    - `.github/workflows/test.yml`: New `version-check` job prevents wasted test runs
+    - All test jobs depend on version-check passing (`needs: version-check`)
+  - **Error Messages**: Clear, actionable error reporting
+    - "Release vX.Y.Z not found in owner/repo"
+    - "Asset filename not found in release vX.Y.Z"
+    - "🚨 CRITICAL: One or more pinned scanner versions do not exist!"
+  - **Benefits**:
+    - ✅ Fail fast: Detect missing versions before attempting download
+    - ✅ Clear errors: Actionable error messages instead of cryptic wget failures
+    - ✅ Prevents CI waste: Don't run tests if scanner install will fail
+    - ✅ Automation-ready: Can be used in version update workflows
+  - **Related**: Parent issue #289 - Version mismatch fix
+
 - **Automated Monthly Prompt Injection Pattern Research Workflow** (Issue #288)
   - **GitHub Actions Workflow**: Monthly automated reminder issues (1st of month, 9am UTC)
     - File: `.github/workflows/pattern-research-reminder.yml`

--- a/scripts/check_scanner_versions.py
+++ b/scripts/check_scanner_versions.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Check if pinned scanner versions exist and are downloadable.
+
+This script verifies that all pinned scanner versions in pyproject.toml
+still exist on GitHub releases and are downloadable. It prevents CI failures
+when versions are yanked or repositories are archived.
+
+Exit codes:
+    0: All pinned scanner versions exist and are downloadable
+    1: One or more pinned scanner versions do not exist
+"""
+
+import sys
+import requests
+import tomllib
+from pathlib import Path
+
+
+def check_scanner_exists(repo: str, version: str, scanner_name: str, platform: str = "linux_x64") -> dict:
+    """
+    Check if a scanner version exists on GitHub releases.
+
+    Args:
+        repo: GitHub repo (e.g., "gitleaks/gitleaks")
+        version: Version to check (e.g., "8.30.1")
+        scanner_name: Name of scanner (gitleaks, betterleaks, leaktk)
+        platform: Platform string (e.g., "linux_x64")
+
+    Returns:
+        dict with exists, download_url, error
+    """
+    # Try release API first
+    api_url = f"https://api.github.com/repos/{repo}/releases/tags/v{version}"
+
+    try:
+        response = requests.get(api_url, timeout=10)
+
+        if response.status_code == 404:
+            return {
+                'exists': False,
+                'error': f'Release v{version} not found in {repo}'
+            }
+
+        response.raise_for_status()
+        release_data = response.json()
+
+        # Build expected asset name based on scanner naming conventions
+        # gitleaks/betterleaks: scanner_version_platform.tar.gz (e.g., gitleaks_8.30.1_linux_x64.tar.gz)
+        # leaktk: scanner-version-system-arch.tar.xz with x86_64 instead of x64 (e.g., leaktk-0.2.10-linux-x86_64.tar.xz)
+        if scanner_name == "leaktk":
+            # leaktk uses hyphens, separate system and arch, and x86_64 instead of x64
+            system, arch = platform.split('_', 1)
+            leaktk_arch = "x86_64" if arch == "x64" else arch
+            asset_name = f"{scanner_name}-{version}-{system}-{leaktk_arch}.tar.xz"
+        else:
+            # gitleaks and betterleaks use underscores
+            asset_name = f"{scanner_name}_{version}_{platform}.tar.gz"
+
+        assets = release_data.get('assets', [])
+        matching_asset = next(
+            (a for a in assets if a['name'] == asset_name),
+            None
+        )
+
+        if not matching_asset:
+            return {
+                'exists': False,
+                'error': f'Asset {asset_name} not found in release v{version}'
+            }
+
+        # Asset exists in release - no need for HEAD request since GitHub API is authoritative
+        return {
+            'exists': True,
+            'download_url': matching_asset['browser_download_url'],
+            'size_mb': round(matching_asset['size'] / 1024 / 1024, 2)
+        }
+
+    except requests.RequestException as e:
+        return {
+            'exists': False,
+            'error': f'Network error checking {repo} v{version}: {e}'
+        }
+
+
+def main():
+    # Load pyproject.toml
+    pyproject_path = Path('pyproject.toml')
+    if not pyproject_path.exists():
+        print("❌ pyproject.toml not found")
+        sys.exit(1)
+
+    with open(pyproject_path, 'rb') as f:
+        config = tomllib.load(f)
+
+    scanners_config = config.get('tool', {}).get('ai-guardian', {}).get('scanners', {})
+    repos_config = scanners_config.get('repos', {})
+
+    if not scanners_config:
+        print("❌ No scanner versions found in pyproject.toml")
+        sys.exit(1)
+
+    print("Checking pinned scanner versions...\n")
+
+    all_exist = True
+
+    for scanner, version in scanners_config.items():
+        if scanner == 'repos':
+            continue  # Skip repos section
+
+        repo = repos_config.get(scanner)
+        if not repo:
+            print(f"⚠️  {scanner}: No repository configured, skipping")
+            continue
+
+        print(f"Checking {scanner} v{version} ({repo})...")
+
+        result = check_scanner_exists(repo, version, scanner)
+
+        if result['exists']:
+            print(f"  ✅ EXISTS - {result['download_url']}")
+            print(f"     Size: {result['size_mb']} MB")
+        else:
+            print(f"  ❌ NOT FOUND - {result['error']}")
+            all_exist = False
+
+        print()
+
+    if not all_exist:
+        print("\n🚨 CRITICAL: One or more pinned scanner versions do not exist!")
+        print("Action required: Update pyproject.toml with valid versions")
+        sys.exit(1)
+
+    print("✅ All pinned scanner versions exist and are downloadable")
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

Related Issue: itdove/ai-guardian#290

## Description
This PR adds a scanner version existence check to prevent broken downloads when users attempt to download non-existent scanner versions. 

A new Python script (`scripts/check_scanner_versions.py`) has been added that validates scanner version availability before allowing downloads to proceed. The GitHub Actions workflows have been updated to integrate this validation check into the CI/CD pipeline, ensuring that any references to scanner versions are validated automatically.

The changes prevent runtime failures caused by attempting to download scanner versions that don't exist or have been removed, improving the reliability of the download process.

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Run the new scanner version check script: `python scripts/check_scanner_versions.py`
3. Verify the script successfully validates existing scanner versions
4. Test with an invalid/non-existent scanner version to confirm proper error handling
5. Trigger the GitHub Actions workflows (integration-tests.yml and test.yml) to verify the check runs correctly in CI
6. Verify that the workflow fails appropriately when an invalid scanner version is referenced

### Scenarios tested
- Scanner version validation with valid versions (passes)
- Scanner version validation with non-existent versions (fails appropriately)
- Integration of version check into GitHub Actions workflows

## Deployment considerations
- [x] This code change is ready for deployment on its own