### PR TITLE
itdove/ai-guardian#309: Configure Dependabot to group all dependency updates into consolidated PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@
 version: 2
 updates:
   # GitHub Actions - Check for action version updates
+  # Grouped to consolidate all action updates into a single PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,6 +18,16 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "itdove"
+    # Group all GitHub Actions updates together (minor, patch, and major)
+    # This reduces PR noise by consolidating all action updates into one PR
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"
 
   # Python packages - Check for pip dependency updates
   - package-ecosystem: "pip"
@@ -32,7 +43,9 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "itdove"
-    # Group minor and patch updates together
+    # Group all Python package updates together (minor, patch, and major)
+    # This reduces PR noise by consolidating all package updates into one PR
+    # Major version updates are included to minimize total number of PRs
     groups:
       python-packages:
         patterns:
@@ -40,6 +53,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+          - "major"
     # Allow both direct and indirect dependencies
     allow:
       - dependency-type: "all"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,6 +431,7 @@ Dependabot automatically monitors and creates pull requests for dependency updat
    - Labels: `ci-cd`, `dependabot`
    - Commit prefix: `ci:`
    - PR limit: 5 concurrent PRs
+   - **Grouping**: All updates (minor, patch, and major) are grouped into single PRs to reduce noise
 
 2. **Python Packages** (from `pyproject.toml`)
    - Monthly checks for package updates
@@ -438,8 +439,7 @@ Dependabot automatically monitors and creates pull requests for dependency updat
    - Labels: `enhancement`, `dependabot`
    - Commit prefix: `deps:`
    - PR limit: 10 concurrent PRs
-   - **Grouping**: Minor and patch updates are grouped into single PRs to reduce noise
-   - **Major updates**: Separate PRs for careful review
+   - **Grouping**: All updates (minor, patch, and major) are grouped into single PRs to reduce noise
 
 **Dependabot vs Scanner Version Checking:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Dependabot Configuration** (Issue #292)
+- **Dependabot Configuration** (Issue #292, #309)
   - **Automated Dependency Updates**: `.github/dependabot.yml`
     - GitHub Actions monitoring: Monthly checks for action version updates
       - Monitors: actions/checkout, actions/setup-python, codecov/codecov-action, etc.
       - Labels: `ci-cd`, `dependabot`
       - Commit prefix: `ci:`
       - PR limit: 5 concurrent
+      - Grouping: All updates (minor, patch, and major) grouped into single PRs
     - Python package monitoring: Monthly checks for pip dependencies
       - Monitors: textual, jsonschema, requests, pyyaml, tomli, pytest, etc.
       - Labels: `enhancement`, `dependabot`
       - Commit prefix: `deps:`
       - PR limit: 10 concurrent
-      - Grouping: Minor and patch updates grouped into single PRs
-      - Major updates: Separate PRs for careful review
+      - Grouping: All updates (minor, patch, and major) grouped into single PRs
   - **Security Benefits**:
     - ✅ Automated CVE alerts: Immediate PRs for security vulnerabilities (regardless of schedule)
     - ✅ Zero-effort monitoring: Dependabot checks automatically


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
<!-- Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN> -->
This PR does not need a corresponding Jira item.

## Description
This PR configures Dependabot to group all dependency updates into consolidated pull requests, reducing PR noise and making dependency management more efficient. The Dependabot configuration has been updated to use grouping rules that bundle related updates together rather than creating individual PRs for each dependency update.

Changes include:
- Updated `.github/dependabot.yml` with grouping configuration to consolidate dependency updates
- Updated `AGENTS.md` to reflect the new Dependabot workflow
- Updated `CHANGELOG.md` to document this change

Assisted-by: Claude

## Testing
### Steps to test
1. Pull down the PR
2. Review the changes to `.github/dependabot.yml` to verify the grouping configuration is correct
3. Wait for the next Dependabot run (or manually trigger Dependabot via GitHub settings)
4. Verify that dependency updates are created as consolidated PRs rather than individual PRs for each dependency
5. Check that grouped PRs have clear titles indicating they contain multiple dependency updates

### Scenarios tested
- Validated Dependabot YAML syntax is correct
- Reviewed grouping configuration to ensure all dependency types are included
- Verified documentation updates align with the new configuration

## Deployment considerations
- [x] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed: