### PR TITLE
feat: add ssrf_blocked and config_file_exfil violation logging types

### DIFF
--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -2708,6 +2708,27 @@ def process_hook_input():
                         if ide_type != IDEType.CURSOR:
                             logging.info(f"Blocking operation for {file_path} due to config file threat")
 
+                        # Log config file exfiltration violation
+                        if HAS_VIOLATION_LOGGER:
+                            try:
+                                violation_logger = ViolationLogger()
+                                violation_logger.log_violation(
+                                    violation_type="config_file_exfil",
+                                    blocked={
+                                        "file_path": file_path,
+                                        "reason": config_error,
+                                        "details": config_details
+                                    },
+                                    context={
+                                        "ide_type": ide_type.value if hasattr(ide_type, 'value') else str(ide_type),
+                                        "hook_event": hook_event,
+                                        "project_path": os.getcwd()
+                                    },
+                                    severity="critical"
+                                )
+                            except Exception as e:
+                                logging.debug(f"Failed to log config file exfil violation: {e}")
+
                         # Include any config errors with the blocking message
                         combined_warning = "\n\n".join(warning_messages) if warning_messages else None
                         return format_response(ide_type, has_secrets=True, error_message=config_error, hook_event=hook_event, warning_message=combined_warning)

--- a/src/ai_guardian/schemas/ai-guardian-config.schema.json
+++ b/src/ai_guardian/schemas/ai-guardian-config.schema.json
@@ -967,9 +967,9 @@
           "description": "Types of violations to log. Empty array logs all types.",
           "items": {
             "type": "string",
-            "enum": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+            "enum": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection", "ssrf_blocked", "config_file_exfil"]
           },
-          "default": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+          "default": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection", "ssrf_blocked", "config_file_exfil"]
         }
       },
       "additionalProperties": false

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -926,7 +926,7 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
             "enabled": True,
             "max_entries": 1000,
             "retention_days": 30,
-            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection", "ssrf_blocked", "config_file_exfil"]
         }
     }
 

--- a/src/ai_guardian/tool_policy.py
+++ b/src/ai_guardian/tool_policy.py
@@ -518,7 +518,8 @@ class ToolPolicyChecker:
                             check_value=tool_input.get("command", str(tool_input)),
                             reason="SSRF attack detected",
                             matcher=tool_name,
-                            hook_data=hook_data
+                            hook_data=hook_data,
+                            violation_type="ssrf_blocked"
                         )
                         return False, error_msg, tool_name
 
@@ -530,7 +531,8 @@ class ToolPolicyChecker:
                             check_value=tool_input.get("command", str(tool_input)),
                             reason="SSRF warning (allowed)",
                             matcher=tool_name,
-                            hook_data=hook_data
+                            hook_data=hook_data,
+                            violation_type="ssrf_blocked"
                         )
                         # Continue to other checks (warning is logged, execution allowed)
 
@@ -1480,7 +1482,8 @@ class ToolPolicyChecker:
         check_value: str,
         reason: str,
         matcher: str,
-        hook_data: Dict
+        hook_data: Dict,
+        violation_type: str = "tool_permission"
     ):
         """
         Log a tool permission violation.
@@ -1491,6 +1494,7 @@ class ToolPolicyChecker:
             reason: Reason for blocking
             matcher: Matcher pattern from the permission rule
             hook_data: Original hook data for context
+            violation_type: Type of violation to log
         """
         if not HAS_VIOLATION_LOGGER:
             return
@@ -1507,7 +1511,7 @@ class ToolPolicyChecker:
 
             # Log the violation
             violation_logger.log_violation(
-                violation_type="tool_permission",
+                violation_type=violation_type,
                 blocked={
                     "tool_name": tool_name,
                     "tool_value": check_value,

--- a/src/ai_guardian/tui/secrets.py
+++ b/src/ai_guardian/tui/secrets.py
@@ -205,6 +205,8 @@ class SecretsContent(Container):
                     yield Checkbox("Secret Detected", id="log-type-secret", value=True)
                     yield Checkbox("Secret Redaction", id="log-type-redaction", value=True)
                     yield Checkbox("Prompt Injection", id="log-type-injection", value=True)
+                    yield Checkbox("SSRF Blocked", id="log-type-ssrf", value=True)
+                    yield Checkbox("Config File Exfil", id="log-type-config-exfil", value=True)
 
     def on_mount(self) -> None:
         """Load configuration when mounted."""
@@ -297,7 +299,7 @@ class SecretsContent(Container):
         log_enabled = violation_logging.get("enabled", True)
         max_entries = violation_logging.get("max_entries", 1000)
         retention_days = violation_logging.get("retention_days", 30)
-        log_types = violation_logging.get("log_types", ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"])
+        log_types = violation_logging.get("log_types", ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection", "ssrf_blocked", "config_file_exfil"])
 
         try:
             self.query_one("#violation-logging-enabled", Checkbox).value = log_enabled
@@ -310,6 +312,8 @@ class SecretsContent(Container):
             self.query_one("#log-type-secret", Checkbox).value = "secret_detected" in log_types
             self.query_one("#log-type-redaction", Checkbox).value = "secret_redaction" in log_types
             self.query_one("#log-type-injection", Checkbox).value = "prompt_injection" in log_types
+            self.query_one("#log-type-ssrf", Checkbox).value = "ssrf_blocked" in log_types
+            self.query_one("#log-type-config-exfil", Checkbox).value = "config_file_exfil" in log_types
         except Exception:
             pass  # Widgets may not be mounted yet
 
@@ -646,6 +650,10 @@ class SecretsContent(Container):
                 log_types.append("secret_redaction")
             if self.query_one("#log-type-injection", Checkbox).value:
                 log_types.append("prompt_injection")
+            if self.query_one("#log-type-ssrf", Checkbox).value:
+                log_types.append("ssrf_blocked")
+            if self.query_one("#log-type-config-exfil", Checkbox).value:
+                log_types.append("config_file_exfil")
 
             config["violation_logging"]["log_types"] = log_types
 

--- a/src/ai_guardian/tui/violations.py
+++ b/src/ai_guardian/tui/violations.py
@@ -336,6 +336,10 @@ class ViolationsContent(Container):
                 yield VerticalScroll(id="violations-list-directory")
             with TabPane("Prompt Injection", id="filter-injection"):
                 yield VerticalScroll(id="violations-list-injection")
+            with TabPane("SSRF Blocked", id="filter-ssrf"):
+                yield VerticalScroll(id="violations-list-ssrf")
+            with TabPane("Config Exfil", id="filter-config-exfil"):
+                yield VerticalScroll(id="violations-list-config-exfil")
 
     def on_mount(self) -> None:
         """Load violations when mounted."""
@@ -380,6 +384,18 @@ class ViolationsContent(Container):
             limit=50, violation_type="prompt_injection", resolved=None
         )
         self._populate_list("#violations-list-injection", injection_violations)
+
+        # Load SSRF blocked violations
+        ssrf_violations = self.violation_logger.get_recent_violations(
+            limit=50, violation_type="ssrf_blocked", resolved=None
+        )
+        self._populate_list("#violations-list-ssrf", ssrf_violations)
+
+        # Load config file exfil violations
+        config_exfil_violations = self.violation_logger.get_recent_violations(
+            limit=50, violation_type="config_file_exfil", resolved=None
+        )
+        self._populate_list("#violations-list-config-exfil", config_exfil_violations)
 
     def _populate_list(self, list_id: str, violations: list) -> None:
         """Populate a violations list."""

--- a/src/ai_guardian/violation_logger.py
+++ b/src/ai_guardian/violation_logger.py
@@ -331,7 +331,7 @@ class ViolationLogger:
             "enabled": True,
             "max_entries": 1000,
             "retention_days": 30,
-            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+            "log_types": ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection", "ssrf_blocked", "config_file_exfil"]
         }
 
     def _is_logging_enabled(self) -> bool:

--- a/tests/unit/test_violation_logging_types.py
+++ b/tests/unit/test_violation_logging_types.py
@@ -1,0 +1,255 @@
+"""Tests for ssrf_blocked and config_file_exfil violation logging types."""
+
+import json
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+
+ALL_LOG_TYPES = [
+    "tool_permission", "directory_blocking", "secret_detected",
+    "secret_redaction", "prompt_injection", "ssrf_blocked", "config_file_exfil"
+]
+
+
+class TestViolationLoggerDefaults:
+    """Test that ViolationLogger default config includes new types."""
+
+    def test_default_config_includes_ssrf_blocked(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                defaults = vl._get_default_config()
+                assert "ssrf_blocked" in defaults["log_types"]
+
+    def test_default_config_includes_config_file_exfil(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                defaults = vl._get_default_config()
+                assert "config_file_exfil" in defaults["log_types"]
+
+    def test_default_config_has_all_seven_types(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                defaults = vl._get_default_config()
+                assert set(defaults["log_types"]) == set(ALL_LOG_TYPES)
+
+
+class TestShouldLogType:
+    """Test _should_log_type filtering for new types."""
+
+    def test_should_log_ssrf_blocked_when_in_config(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = os.path.join(tmp, "ai-guardian.json")
+            with open(config_path, 'w') as f:
+                json.dump({"violation_logging": {"log_types": ["ssrf_blocked"]}}, f)
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                assert vl._should_log_type("ssrf_blocked") is True
+                assert vl._should_log_type("tool_permission") is False
+
+    def test_should_log_config_file_exfil_when_in_config(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = os.path.join(tmp, "ai-guardian.json")
+            with open(config_path, 'w') as f:
+                json.dump({"violation_logging": {"log_types": ["config_file_exfil"]}}, f)
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                assert vl._should_log_type("config_file_exfil") is True
+                assert vl._should_log_type("tool_permission") is False
+
+    def test_should_log_all_when_empty_log_types(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = os.path.join(tmp, "ai-guardian.json")
+            with open(config_path, 'w') as f:
+                json.dump({"violation_logging": {"log_types": []}}, f)
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                assert vl._should_log_type("ssrf_blocked") is True
+                assert vl._should_log_type("config_file_exfil") is True
+
+    def test_old_config_without_new_types_skips_them(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = os.path.join(tmp, "ai-guardian.json")
+            old_types = ["tool_permission", "directory_blocking", "secret_detected", "secret_redaction", "prompt_injection"]
+            with open(config_path, 'w') as f:
+                json.dump({"violation_logging": {"log_types": old_types}}, f)
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                assert vl._should_log_type("ssrf_blocked") is False
+                assert vl._should_log_type("config_file_exfil") is False
+                assert vl._should_log_type("tool_permission") is True
+
+
+class TestSetupDefaults:
+    """Test that setup.py default config template includes new types."""
+
+    def test_default_config_template_includes_new_types(self):
+        from ai_guardian.setup import _get_default_config_template
+        config = _get_default_config_template(permissive=False)
+        log_types = config["violation_logging"]["log_types"]
+        assert "ssrf_blocked" in log_types
+        assert "config_file_exfil" in log_types
+
+    def test_permissive_config_template_includes_new_types(self):
+        from ai_guardian.setup import _get_default_config_template
+        config = _get_default_config_template(permissive=True)
+        log_types = config["violation_logging"]["log_types"]
+        assert "ssrf_blocked" in log_types
+        assert "config_file_exfil" in log_types
+
+
+class TestSchemaValidation:
+    """Test that JSON schema accepts new violation types."""
+
+    def test_schema_accepts_ssrf_blocked(self):
+        import jsonschema
+        schema_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            "src", "ai_guardian", "schemas", "ai-guardian-config.schema.json"
+        )
+        with open(schema_path) as f:
+            schema = json.load(f)
+
+        config = {"violation_logging": {"log_types": ["ssrf_blocked"]}}
+        jsonschema.validate(config, schema)
+
+    def test_schema_accepts_config_file_exfil(self):
+        import jsonschema
+        schema_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            "src", "ai_guardian", "schemas", "ai-guardian-config.schema.json"
+        )
+        with open(schema_path) as f:
+            schema = json.load(f)
+
+        config = {"violation_logging": {"log_types": ["config_file_exfil"]}}
+        jsonschema.validate(config, schema)
+
+    def test_schema_accepts_all_seven_types(self):
+        import jsonschema
+        schema_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            "src", "ai_guardian", "schemas", "ai-guardian-config.schema.json"
+        )
+        with open(schema_path) as f:
+            schema = json.load(f)
+
+        config = {"violation_logging": {"log_types": ALL_LOG_TYPES}}
+        jsonschema.validate(config, schema)
+
+    def test_schema_rejects_invalid_type(self):
+        import jsonschema
+        schema_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            "src", "ai_guardian", "schemas", "ai-guardian-config.schema.json"
+        )
+        with open(schema_path) as f:
+            schema = json.load(f)
+
+        config = {"violation_logging": {"log_types": ["invalid_type"]}}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(config, schema)
+
+
+class TestToolPolicySSRFViolationType:
+    """Test that tool_policy._log_violation passes violation_type correctly."""
+
+    @mock.patch('ai_guardian.tool_policy.ViolationLogger')
+    @mock.patch('ai_guardian.tool_policy.HAS_VIOLATION_LOGGER', True)
+    def test_log_violation_default_type_is_tool_permission(self, mock_vl_class):
+        from ai_guardian.tool_policy import ToolPolicyChecker
+        mock_logger = mock.MagicMock()
+        mock_vl_class.return_value = mock_logger
+
+        checker = ToolPolicyChecker(config={"permissions": {"enabled": True, "rules": []}})
+        checker._log_violation(
+            tool_name="Bash",
+            check_value="ls",
+            reason="test reason",
+            matcher="Bash",
+            hook_data={}
+        )
+        mock_logger.log_violation.assert_called_once()
+        call_kwargs = mock_logger.log_violation.call_args
+        assert call_kwargs.kwargs.get("violation_type", call_kwargs[1].get("violation_type")) == "tool_permission"
+
+    @mock.patch('ai_guardian.tool_policy.ViolationLogger')
+    @mock.patch('ai_guardian.tool_policy.HAS_VIOLATION_LOGGER', True)
+    def test_log_violation_ssrf_type(self, mock_vl_class):
+        from ai_guardian.tool_policy import ToolPolicyChecker
+        mock_logger = mock.MagicMock()
+        mock_vl_class.return_value = mock_logger
+
+        checker = ToolPolicyChecker(config={"permissions": {"enabled": True, "rules": []}})
+        checker._log_violation(
+            tool_name="Bash",
+            check_value="curl http://169.254.169.254",
+            reason="SSRF attack detected",
+            matcher="Bash",
+            hook_data={},
+            violation_type="ssrf_blocked"
+        )
+        mock_logger.log_violation.assert_called_once()
+        call_kwargs = mock_logger.log_violation.call_args
+        assert call_kwargs.kwargs.get("violation_type", call_kwargs[1].get("violation_type")) == "ssrf_blocked"
+
+
+class TestViolationLogging:
+    """Test that violations are actually logged with correct types."""
+
+    def test_ssrf_blocked_violation_is_logged(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                vl.log_violation(
+                    violation_type="ssrf_blocked",
+                    blocked={"tool_name": "Bash", "reason": "SSRF attack detected"},
+                    context={"hook_event": "pretooluse"}
+                )
+                violations = vl.get_recent_violations(limit=10)
+                assert len(violations) == 1
+                assert violations[0]["violation_type"] == "ssrf_blocked"
+
+    def test_config_file_exfil_violation_is_logged(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                vl.log_violation(
+                    violation_type="config_file_exfil",
+                    blocked={"file_path": "/etc/shadow", "reason": "config exfiltration"},
+                    context={"hook_event": "pretooluse"},
+                    severity="critical"
+                )
+                violations = vl.get_recent_violations(limit=10)
+                assert len(violations) == 1
+                assert violations[0]["violation_type"] == "config_file_exfil"
+
+    def test_ssrf_not_logged_when_excluded_from_config(self):
+        from ai_guardian.violation_logger import ViolationLogger
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = os.path.join(tmp, "ai-guardian.json")
+            with open(config_path, 'w') as f:
+                json.dump({"violation_logging": {"log_types": ["tool_permission"]}}, f)
+            with mock.patch.dict(os.environ, {'AI_GUARDIAN_CONFIG_DIR': tmp}):
+                vl = ViolationLogger()
+                vl.log_violation(
+                    violation_type="ssrf_blocked",
+                    blocked={"tool_name": "Bash", "reason": "SSRF"},
+                    context={}
+                )
+                violations = vl.get_recent_violations(limit=10)
+                assert len(violations) == 0


### PR DESCRIPTION
Closes #322

## Description

SSRF detections were misclassified as `tool_permission`, and config file exfiltration threats produced no audit trail. This adds dedicated violation types (`ssrf_blocked` and `config_file_exfil`) for both, enabling accurate filtering, independent configuration, and complete audit coverage.

Assisted-by: Claude Code (Claude Opus 4.6)

### Changes

| File | Change |
|------|--------|
| `src/ai_guardian/schemas/ai-guardian-config.schema.json` | Added `ssrf_blocked` and `config_file_exfil` to `log_types` enum and default |
| `src/ai_guardian/violation_logger.py` | Updated `_get_default_config()` with new types |
| `src/ai_guardian/setup.py` | Updated `_get_default_config_template()` with new types |
| `src/ai_guardian/tool_policy.py` | Added `violation_type` param to `_log_violation()`; SSRF now logs as `ssrf_blocked` |
| `src/ai_guardian/__init__.py` | Added `config_file_exfil` violation logging when config threats are blocked |
| `src/ai_guardian/tui/secrets.py` | Added checkboxes for new log types |
| `src/ai_guardian/tui/violations.py` | Added filter tabs for new violation types |
| `tests/unit/test_violation_logging_types.py` | 18 new tests covering defaults, filtering, schema, and logging |

### Backward compatibility

- Existing configs with an explicit 5-type `log_types` list will silently skip new types until manually updated (safe behavior)
- The `_should_log_type()` method falls through to "log all" when `log_types` is empty, so users with default configs get the new types automatically

## Testing

### Steps to test
1. Pull down the PR
2. Run `pytest` — all 1389 tests pass (18 new)
3. Run `pytest tests/unit/test_violation_logging_types.py -v` to verify new tests specifically
4. Verify schema with: `python -c "import json, jsonschema; schema=json.load(open('src/ai_guardian/schemas/ai-guardian-config.schema.json')); jsonschema.validate({'violation_logging': {'log_types': ['ssrf_blocked', 'config_file_exfil']}}, schema); print('OK')"`

### Scenarios tested
- Default config includes all 7 violation types
- Schema validates new types and rejects invalid ones
- `_should_log_type()` correctly filters new types
- Old 5-type configs skip new types (backward compat)
- Empty log_types logs everything (fallback behavior)
- `_log_violation()` passes `violation_type` parameter correctly
- SSRF blocking logs as `ssrf_blocked` (not `tool_permission`)
- Config file exfiltration logs as `config_file_exfil`
- Violations not logged when excluded from config

## Deployment considerations
- [x] This code change is ready for deployment on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)