### PR TITLE
feat: add allow_symlinks flag and plugin cache discovery for auto_directory_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **allow_symlinks flag and plugin cache discovery for auto_directory_rules** (Issue #324)
+  - Added `allow_symlinks` boolean property (default: `true`) to `auto_directory_rules` config
+  - In container environments (e.g., carbonite), skills are installed as symlinks — previously all symlinks were unconditionally skipped, making auto-generated directory rules non-functional
+  - When `true`, symlinked skill directories that resolve to valid directories are followed
+  - When `false`, all symlinks are skipped (original behavior)
+  - Broken symlinks are always skipped regardless of this setting
+  - Added plugin cache directory scanning: `~/.claude/plugins/cache/*/*/*/skills/` — skills installed via Claude Code plugins are now discovered automatically
+  - Updated schema, setup.py default config, and example config
+  - Added 11 test cases covering symlink handling, plugin cache discovery, and edge cases
+
 - **Scanner/Pattern-Server Discovery Commands** (Issue #320)
   - `ai-guardian scanner supported` — lists all supported scanners with versions, repos, and licenses
   - `ai-guardian pattern-servers supported` — lists all configured pattern servers with URLs and endpoints

--- a/ai-guardian-example.json
+++ b/ai-guardian-example.json
@@ -25,6 +25,13 @@
     "_comment4": "Works with permissions_directories (auto-discovery feeds INTO this section)",
     "_comment5": "NEW unified structure in v1.4.0: combines enabled flag and rules in one object",
     "enabled": true,
+    "auto_directory_rules": {
+      "_comment": "Auto-generate directory rules from skill permissions (Issue #144)",
+      "_comment2": "allow_symlinks: In container environments (e.g., carbonite), skills are installed as symlinks.",
+      "_comment3": "Set to false to skip all symlinks (original behavior). Broken symlinks are always skipped.",
+      "enabled": false,
+      "allow_symlinks": true
+    },
     "rules": [
       {
         "_comment": "Skills - must be explicitly allowed",

--- a/src/ai_guardian/directory_rule_generator.py
+++ b/src/ai_guardian/directory_rule_generator.py
@@ -84,6 +84,12 @@ class DirectoryRuleGenerator:
         logger.info(f"Generated {len(generated_rules)} directory rules from skill permissions")
         return generated_rules
 
+    def _get_allow_symlinks(self) -> bool:
+        """Return whether symlinks should be followed during skill discovery."""
+        permissions = self.config.get("permissions", {})
+        auto_config = permissions.get("auto_directory_rules", {})
+        return auto_config.get("allow_symlinks", True)
+
     def _get_skill_patterns(self) -> List[str]:
         """
         Extract skill permission patterns from config.
@@ -158,6 +164,7 @@ class DirectoryRuleGenerator:
 
         Supports multiple IDE agents:
         - Claude Code: ./.claude/skills, ~/.claude/skills, $CLAUDE_CONFIG_DIR/skills
+        - Claude Code plugins: ~/.claude/plugins/cache/*/*/*/skills
         - Cursor: ./.cursor/skills, ~/.cursor/skills
         - VSCode/Copilot: ./.vscode/skills, ~/.vscode/skills
         - Windsurf: ./.windsurf/skills, ~/.windsurf/skills
@@ -185,6 +192,17 @@ class DirectoryRuleGenerator:
                 Path.home() / ".vscode" / "skills",
                 Path.home() / ".windsurf" / "skills",
             ]
+
+            # Plugin cache directories (skills installed via plugins)
+            # Structure: ~/.claude/plugins/cache/<marketplace>/<plugin>/<hash>/skills/
+            plugin_cache = Path.home() / ".claude" / "plugins" / "cache"
+            if plugin_cache.is_dir():
+                try:
+                    for skills_dir in plugin_cache.glob("*/*/*/skills"):
+                        if skills_dir.is_dir():
+                            candidate_dirs.append(skills_dir)
+                except Exception as e:
+                    logger.warning(f"Error scanning plugin cache {plugin_cache}: {e}")
 
             # Add IDE-specific config directories from environment
             # Claude Code
@@ -231,24 +249,25 @@ class DirectoryRuleGenerator:
             Example: {"daf-git": [Path("~/.claude/skills/daf-git")], ...}
         """
         skills = {}
+        allow_symlinks = self._get_allow_symlinks()
 
         for skill_dir in skill_dirs:
             try:
-                # List all subdirectories (each is a potential skill)
                 for item in skill_dir.iterdir():
-                    # Skip symlinks for security (prevent following links outside skill dirs)
                     if item.is_symlink():
-                        logger.warning(f"Skipping symlink in skill directory: {item}")
-                        continue
+                        if not allow_symlinks:
+                            logger.warning(f"Skipping symlink in skill directory: {item}")
+                            continue
+                        if not item.resolve().is_dir():
+                            logger.warning(f"Skipping broken symlink in skill directory: {item}")
+                            continue
 
                     if item.is_dir():
                         skill_name = item.name
 
-                        # Skip hidden directories and special directories
                         if skill_name.startswith(".") or skill_name.startswith("__"):
                             continue
 
-                        # Add to skills dict
                         if skill_name not in skills:
                             skills[skill_name] = []
                         skills[skill_name].append(item)
@@ -337,12 +356,17 @@ class DirectoryRuleGenerator:
         skill_dirs = self._get_skill_directories(auto_config)
 
         locations = {}
+        allow_symlinks = self._get_allow_symlinks()
 
         for skill_dir in skill_dirs:
             skills_in_dir = set()
 
             try:
                 for item in skill_dir.iterdir():
+                    if item.is_symlink() and not allow_symlinks:
+                        continue
+                    if item.is_symlink() and not item.resolve().is_dir():
+                        continue
                     if item.is_dir() and item.name in skill_names:
                         skills_in_dir.add(item.name)
             except Exception as e:

--- a/src/ai_guardian/schemas/ai-guardian-config.schema.json
+++ b/src/ai_guardian/schemas/ai-guardian-config.schema.json
@@ -53,6 +53,11 @@
               ],
               "description": "Skill directories to scan for auto-generation. Default: 'auto' scans standard locations (./.claude/skills, ~/.claude/skills, $CLAUDE_CONFIG_DIR/skills). Can also provide explicit array of paths.",
               "default": "auto"
+            },
+            "allow_symlinks": {
+              "type": "boolean",
+              "description": "Allow following symlinks when discovering skills. Default: true. In container environments (e.g., carbonite), skills are installed as symlinks. When true, symlinked skill directories that resolve to valid directories are followed. When false, all symlinks are skipped (original behavior). Broken symlinks are always skipped regardless of this setting.",
+              "default": true
             }
           },
           "additionalProperties": false

--- a/src/ai_guardian/setup.py
+++ b/src/ai_guardian/setup.py
@@ -877,6 +877,10 @@ def _get_default_config_template(permissive: bool = False) -> Dict:
         "_comment_permissions": "Control which tools (Skills, MCP servers, Bash, etc.) are allowed to run",
         "permissions": {
             "enabled": not permissive,
+            "auto_directory_rules": {
+                "enabled": False,
+                "allow_symlinks": True
+            },
             "rules": [] if permissive else [
                 {
                     "_comment": "Skills - Blocked by default. Add allow rules via TUI.",

--- a/tests/unit/test_auto_directory_rules.py
+++ b/tests/unit/test_auto_directory_rules.py
@@ -445,3 +445,243 @@ class TestMultiIDESupport:
         assert len(dirs) == 2
         assert Path("/custom/path/skills") in dirs
         assert Path("/another/path/skills") in dirs
+
+
+class TestPluginCacheDiscovery:
+    """Test discovery of skills in plugin cache directories (Issue #324)."""
+
+    def test_plugin_cache_skills_discovered(self, tmp_path):
+        """Skills in plugin cache should be discovered automatically."""
+        # Create plugin cache structure:
+        # ~/.claude/plugins/cache/<marketplace>/<plugin>/<hash>/skills/<skill>/
+        cache_dir = tmp_path / ".claude" / "plugins" / "cache"
+        skills_dir = cache_dir / "marketplace" / "my-plugin" / "abc123" / "skills"
+        (skills_dir / "bugfix-workflow").mkdir(parents=True)
+        (skills_dir / "code-review").mkdir(parents=True)
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {"enabled": True},
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["bugfix-workflow", "code-review"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+
+        with patch('ai_guardian.directory_rule_generator.Path.home', return_value=tmp_path):
+            rules = generator.generate_directory_rules()
+
+        assert len(rules) > 0
+        assert any("bugfix-workflow" in str(rule) for rule in rules)
+        assert any("code-review" in str(rule) for rule in rules)
+
+    def test_plugin_cache_empty(self, tmp_path):
+        """Empty plugin cache should not cause errors."""
+        cache_dir = tmp_path / ".claude" / "plugins" / "cache"
+        cache_dir.mkdir(parents=True)
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {
+                    "enabled": True,
+                    "skill_directories": [str(cache_dir)]
+                },
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["*"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+        rules = generator.generate_directory_rules()
+
+        assert rules == []
+
+    def test_plugin_cache_missing(self, tmp_path):
+        """Missing plugin cache directory should not cause errors."""
+        missing_dir = tmp_path / "nonexistent" / "skills"
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {
+                    "enabled": True,
+                    "skill_directories": [str(missing_dir)]
+                },
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["*"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+        rules = generator.generate_directory_rules()
+
+        assert rules == []
+
+
+class TestSymlinkHandling:
+    """Test allow_symlinks flag for container environments (Issue #324)."""
+
+    @patch('ai_guardian.directory_rule_generator.Path.exists')
+    @patch('ai_guardian.directory_rule_generator.Path.is_dir')
+    @patch('ai_guardian.directory_rule_generator.Path.iterdir')
+    def test_symlinks_allowed_by_default(self, mock_iterdir, mock_is_dir, mock_exists):
+        """Symlinked skills should be discovered when allow_symlinks is not set (default: true)."""
+        mock_exists.return_value = True
+        mock_is_dir.return_value = True
+
+        mock_symlink_skill = MagicMock()
+        mock_symlink_skill.name = "daf-git"
+        mock_symlink_skill.is_symlink.return_value = True
+        mock_symlink_skill.is_dir.return_value = True
+        mock_symlink_skill.resolve.return_value = MagicMock(is_dir=MagicMock(return_value=True))
+
+        mock_real_skill = MagicMock()
+        mock_real_skill.name = "gh-cli"
+        mock_real_skill.is_symlink.return_value = False
+        mock_real_skill.is_dir.return_value = True
+
+        mock_iterdir.return_value = [mock_symlink_skill, mock_real_skill]
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {"enabled": True},
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["daf-*", "gh-cli"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+        rules = generator.generate_directory_rules()
+
+        assert len(rules) > 0
+        assert any("daf-git" in str(rule) for rule in rules)
+        assert any("gh-cli" in str(rule) for rule in rules)
+
+    @patch('ai_guardian.directory_rule_generator.Path.exists')
+    @patch('ai_guardian.directory_rule_generator.Path.is_dir')
+    @patch('ai_guardian.directory_rule_generator.Path.iterdir')
+    def test_symlinks_allowed_explicitly(self, mock_iterdir, mock_is_dir, mock_exists):
+        """Symlinked skills should be discovered when allow_symlinks is explicitly true."""
+        mock_exists.return_value = True
+        mock_is_dir.return_value = True
+
+        mock_symlink_skill = MagicMock()
+        mock_symlink_skill.name = "daf-jira"
+        mock_symlink_skill.is_symlink.return_value = True
+        mock_symlink_skill.is_dir.return_value = True
+        mock_symlink_skill.resolve.return_value = MagicMock(is_dir=MagicMock(return_value=True))
+
+        mock_iterdir.return_value = [mock_symlink_skill]
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {"enabled": True, "allow_symlinks": True},
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["daf-*"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+        rules = generator.generate_directory_rules()
+
+        assert len(rules) > 0
+        assert any("daf-jira" in str(rule) for rule in rules)
+
+    @patch('ai_guardian.directory_rule_generator.Path.exists')
+    @patch('ai_guardian.directory_rule_generator.Path.is_dir')
+    @patch('ai_guardian.directory_rule_generator.Path.iterdir')
+    def test_symlinks_rejected_when_disabled(self, mock_iterdir, mock_is_dir, mock_exists):
+        """Symlinked skills should be skipped when allow_symlinks is false."""
+        mock_exists.return_value = True
+        mock_is_dir.return_value = True
+
+        mock_symlink_skill = MagicMock()
+        mock_symlink_skill.name = "daf-git"
+        mock_symlink_skill.is_symlink.return_value = True
+        mock_symlink_skill.is_dir.return_value = True
+
+        mock_real_skill = MagicMock()
+        mock_real_skill.name = "gh-cli"
+        mock_real_skill.is_symlink.return_value = False
+        mock_real_skill.is_dir.return_value = True
+
+        mock_iterdir.return_value = [mock_symlink_skill, mock_real_skill]
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {"enabled": True, "allow_symlinks": False},
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["daf-*", "gh-cli"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+        rules = generator.generate_directory_rules()
+
+        assert len(rules) > 0
+        assert not any("daf-git" in str(rule) for rule in rules)
+        assert any("gh-cli" in str(rule) for rule in rules)
+
+    @patch('ai_guardian.directory_rule_generator.Path.exists')
+    @patch('ai_guardian.directory_rule_generator.Path.is_dir')
+    @patch('ai_guardian.directory_rule_generator.Path.iterdir')
+    def test_broken_symlinks_always_skipped(self, mock_iterdir, mock_is_dir, mock_exists):
+        """Broken symlinks should always be skipped regardless of allow_symlinks."""
+        mock_exists.return_value = True
+        mock_is_dir.return_value = True
+
+        mock_broken_symlink = MagicMock()
+        mock_broken_symlink.name = "broken-skill"
+        mock_broken_symlink.is_symlink.return_value = True
+        mock_broken_symlink.is_dir.return_value = False
+        mock_broken_symlink.resolve.return_value = MagicMock(is_dir=MagicMock(return_value=False))
+
+        mock_real_skill = MagicMock()
+        mock_real_skill.name = "daf-git"
+        mock_real_skill.is_symlink.return_value = False
+        mock_real_skill.is_dir.return_value = True
+
+        mock_iterdir.return_value = [mock_broken_symlink, mock_real_skill]
+
+        config = {
+            "permissions": {
+                "auto_directory_rules": {"enabled": True, "allow_symlinks": True},
+                "rules": [
+                    {"matcher": "Skill", "mode": "allow", "patterns": ["*"]}
+                ]
+            }
+        }
+
+        generator = DirectoryRuleGenerator(config)
+        rules = generator.generate_directory_rules()
+
+        assert not any("broken-skill" in str(rule) for rule in rules)
+        assert any("daf-git" in str(rule) for rule in rules)
+
+    def test_get_allow_symlinks_default(self):
+        """_get_allow_symlinks should return True when not configured."""
+        generator = DirectoryRuleGenerator({"permissions": {"auto_directory_rules": {}}})
+        assert generator._get_allow_symlinks() is True
+
+    def test_get_allow_symlinks_explicit_true(self):
+        """_get_allow_symlinks should return True when explicitly set."""
+        config = {"permissions": {"auto_directory_rules": {"allow_symlinks": True}}}
+        generator = DirectoryRuleGenerator(config)
+        assert generator._get_allow_symlinks() is True
+
+    def test_get_allow_symlinks_explicit_false(self):
+        """_get_allow_symlinks should return False when explicitly set."""
+        config = {"permissions": {"auto_directory_rules": {"allow_symlinks": False}}}
+        generator = DirectoryRuleGenerator(config)
+        assert generator._get_allow_symlinks() is False
+
+    def test_get_allow_symlinks_missing_config(self):
+        """_get_allow_symlinks should return True when config sections are missing."""
+        generator = DirectoryRuleGenerator({})
+        assert generator._get_allow_symlinks() is True


### PR DESCRIPTION
Jira Issue: N/A — GitHub Issue #324
<!-- This PR does not need a corresponding Jira item. -->

## Description

In container environments (e.g., carbonite), the `auto_directory_rules` feature was completely non-functional because:

1. `_discover_skills()` unconditionally rejected all symlinks — in carbonite, skills may be installed as symlinks
2. Plugin cache paths (`~/.claude/plugins/cache/*/*/*/skills/`) were not scanned — in carbonite, skills installed via Claude Code plugins live here, not in `~/.claude/skills/`

### Changes

- **`allow_symlinks` config flag** (default: `true`): When `true`, symlinked skill directories that resolve to valid directories are followed. When `false`, all symlinks are skipped (original behavior). Broken symlinks are always skipped regardless.
- **Plugin cache scanning**: Auto-discovers skills in `~/.claude/plugins/cache/<marketplace>/<plugin>/<hash>/skills/`
- **Schema**: Added `allow_symlinks` boolean property to `auto_directory_rules`
- **Setup.py**: Added `auto_directory_rules` with defaults to `_get_default_config_template()`
- **Example config**: Added `auto_directory_rules` section with `allow_symlinks` example

Assisted-by: Claude Code (Claude Opus 4.6)

## Testing

### Steps to test
1. Pull down the PR
2. Run `pytest` — all 1400 tests pass (11 new tests added)
3. Verify in container environment: `ai-guardian config show --all --json` should show auto-generated directory rules for plugin-installed skills
4. Verify locally: existing behavior unchanged (skills in `~/.claude/skills/` still discovered)

### Scenarios tested
- Symlinks allowed by default (no config change needed)
- Symlinks explicitly enabled (`allow_symlinks: true`)
- Symlinks rejected when disabled (`allow_symlinks: false`)
- Broken symlinks always skipped regardless of flag
- Plugin cache skills discovered automatically
- Empty/missing plugin cache handled gracefully
- Verified in carbonite container — auto-generated rules now appear

## Deployment considerations
- [x] This code change is ready for deployment on its own

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>