### PR TITLE
fix(tests): add autouse fixture to isolate tests from real config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Test isolation: prevent tests from writing to real violations.jsonl** (Issue #344)
+  - Added `autouse` fixture `_isolate_config_dir` that redirects `AI_GUARDIAN_CONFIG_DIR` to a temporary directory for every test
+  - Eliminates 211+ spurious violation entries written to the user's audit log per `pytest` run
+  - Fixed 5 setup tests that relied on `XDG_CONFIG_HOME` without clearing `AI_GUARDIAN_CONFIG_DIR`
+  - Fixed `test_startup_version_logging` to use the file handler's actual path instead of `get_config_dir()`
+
 ### Added
 
 - **Jailbreak Detection Patterns** (Issue #263)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,21 @@ from unittest import mock
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path):
+    """
+    Automatically isolate every test from the real config directory.
+
+    Prevents tests from writing to the user's real violations.jsonl
+    or reading the user's ai-guardian.json. Every test gets its own
+    temporary config directory via the AI_GUARDIAN_CONFIG_DIR env var.
+    """
+    config_dir = tmp_path / "auto_config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    with mock.patch.dict(os.environ, {"AI_GUARDIAN_CONFIG_DIR": str(config_dir)}):
+        yield config_dir
+
+
 @pytest.fixture
 def isolated_config_dir(tmp_path):
     """

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -391,7 +391,7 @@ class TestIDESetup:
 
         config_file = tmp_path / 'ai-guardian' / 'ai-guardian.json'
 
-        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path)}):
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path), 'AI_GUARDIAN_CONFIG_DIR': ''}):
             success, message = setup.setup_remote_config('https://example.com/policy.json', dry_run=False)
 
             assert success is True
@@ -418,7 +418,7 @@ class TestIDESetup:
         existing_config = {'permissions': []}
         config_file.write_text(json.dumps(existing_config))
 
-        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path)}):
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path), 'AI_GUARDIAN_CONFIG_DIR': ''}):
             success, message = setup.setup_remote_config('https://example.com/policy.json', dry_run=False)
 
             assert success is True
@@ -448,7 +448,7 @@ class TestIDESetup:
         }
         config_file.write_text(json.dumps(existing_config))
 
-        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path)}):
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path), 'AI_GUARDIAN_CONFIG_DIR': ''}):
             success, message = setup.setup_remote_config('https://example.com/policy2.json', dry_run=False)
 
             assert success is True
@@ -478,7 +478,7 @@ class TestIDESetup:
         }
         config_file.write_text(json.dumps(existing_config))
 
-        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path)}):
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path), 'AI_GUARDIAN_CONFIG_DIR': ''}):
             success, message = setup.setup_remote_config('https://example.com/policy.json', dry_run=False)
 
             assert success is False
@@ -861,7 +861,7 @@ class TestSetupHooks:
         config_file.parent.mkdir(parents=True, exist_ok=True)
         config_file.write_text('invalid json {')
 
-        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path)}):
+        with mock.patch.dict(os.environ, {'XDG_CONFIG_HOME': str(tmp_path), 'AI_GUARDIAN_CONFIG_DIR': ''}):
             success, message = setup.setup_remote_config('https://example.com/policy.json', dry_run=False)
 
             assert success is False

--- a/tests/unit/test_version_logging.py
+++ b/tests/unit/test_version_logging.py
@@ -48,10 +48,10 @@ class VersionLoggingTest(TestCase):
 
     def test_startup_version_logging(self):
         """Test that version is logged at startup"""
-        # Read the log file to verify startup messages
-        # Note: This test verifies the logging was set up, not that it ran
-        # because the module is already imported
-        log_file = ai_guardian.get_config_dir() / "ai-guardian.log"
+        # The file handler path is fixed at import time (real config dir),
+        # so use the handler's actual path rather than get_config_dir()
+        # which may point to an isolated temp dir during tests.
+        log_file = Path(ai_guardian._file_handler.baseFilename)
 
         # The log file should exist after import
         self.assertTrue(log_file.exists(), "Log file should exist after module import")


### PR DESCRIPTION
Jira Issue: N/A — GitHub Issue https://github.com/itdove/ai-guardian/issues/344
<!-- This PR does not need a corresponding Jira item. -->

## Description

Every `pytest` run was writing 211+ spurious violation entries to the user's real `~/.config/ai-guardian/violations.jsonl` audit log. This happened because 9+ test files call `process_hook_input()` which triggers `ViolationLogger`, and those tests didn't use the `isolated_config_dir` fixture.

**Root cause:** `ViolationLogger.__init__()` calls `get_config_dir()` which defaults to `~/.config/ai-guardian/` when no isolation env var is set.

**Fix:** Added an `autouse` pytest fixture (`_isolate_config_dir`) in `tests/conftest.py` that redirects `AI_GUARDIAN_CONFIG_DIR` to a per-test temporary directory. This ensures every test — including those calling `process_hook_input()` — writes to an isolated temp dir instead of the real config.

**Secondary fixes:**
- 5 setup tests that set `XDG_CONFIG_HOME` now also clear `AI_GUARDIAN_CONFIG_DIR` (since `AI_GUARDIAN_CONFIG_DIR` takes priority in `get_config_dir()`)
- `test_startup_version_logging` now uses the file handler's actual path instead of `get_config_dir()` (the log file is written at import time to the real config dir, not the test's isolated dir)

Assisted-by: Claude Code (Claude Opus 4.6)

## Testing

### Steps to test
1. Pull down the PR
2. Clear violations.jsonl: `truncate -s 0 ~/.config/ai-guardian/violations.jsonl`
3. Run `pytest`
4. Check violations.jsonl: `wc -l ~/.config/ai-guardian/violations.jsonl` → should be **0**

### Scenarios tested
- Full test suite: 1584 passed, 6 skipped, 0 failures
- Verified 0 violations written to real config dir after pytest run (was 211+)
- Verified tests that use `XDG_CONFIG_HOME` still work correctly
- Verified `test_startup_version_logging` passes with isolated config dir

## Deployment considerations
- [x] This code change is ready for deployment on its own

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)