### PR TITLE
itdove/ai-guardian#343: Display warning instead of blocking when default scanner is not installed

### DIFF
--- a/src/ai_guardian/__init__.py
+++ b/src/ai_guardian/__init__.py
@@ -1918,35 +1918,16 @@ def check_secrets_with_gitleaks(content, filename="temp_file", context: Optional
                     config_source = f"{engine_config.type} defaults"
 
                 except RuntimeError as e:
-                    # NO SCANNER AVAILABLE - BLOCK
-                    error_msg = (
-                        f"\n{'='*70}\n"
-                        f"🚨 BLOCKED BY POLICY\n"
-                        f"🔒 NO SCANNER AVAILABLE\n"
-                        f"{'='*70}\n\n"
-                        f"Secret scanning is enabled but no scanner is available.\n\n"
+                    # NO SCANNER AVAILABLE - WARN (allow operation to continue)
+                    default_scanner = engines_list[0] if engines_list else "gitleaks"
+                    warning_msg = (
+                        f"⚠️  WARNING: Default scanner not installed\n\n"
+                        f"Please install the {default_scanner}, with the command:\n"
+                        f"  ai-guardian scanner install {default_scanner}\n\n"
+                        f"Until the scanner is not installed, you may leak secrets."
                     )
-
-                    if pattern_server_attempted:
-                        error_msg += (
-                            f"Attempted fallback:\n"
-                            f"  1. Pattern server: {pattern_config.get('url')} - unavailable\n"
-                            f"  2. Scanner engines: {engines_list} - none installed\n\n"
-                        )
-                    else:
-                        error_msg += (
-                            f"Tried scanner engines: {engines_list} - none installed\n\n"
-                        )
-
-                    error_msg += (
-                        f"This operation has been blocked for security.\n\n"
-                        f"To fix:\n"
-                        f"  1. Install a scanner: brew install gitleaks\n"
-                        f"  2. OR disable secret_scanning in config\n"
-                        f"{'='*70}\n"
-                    )
-                    logging.error(f"No scanner available")
-                    return True, error_msg
+                    logging.warning(f"No scanner available - warning user")
+                    return False, warning_msg
 
             # Validate pattern completeness if using pattern server
             if config_source == "pattern server" and gitleaks_config_path:
@@ -1977,20 +1958,16 @@ def check_secrets_with_gitleaks(content, filename="temp_file", context: Optional
                     engines_list = scanner_config.get("engines", ["gitleaks"]) if scanner_config else ["gitleaks"]
                     engine_config = select_engine(engines_list)
                 except RuntimeError as e:
-                    # No scanner found - error already logged
-                    error_msg = (
-                        f"\n{'='*70}\n"
-                        f"🚨 BLOCKED BY POLICY\n"
-                        f"🔒 NO SCANNER AVAILABLE\n"
-                        f"{'='*70}\n\n"
-                        f"{str(e)}\n\n"
-                        f"Secret scanning is enabled but no scanner is available.\n\n"
-                        f"This operation has been blocked for security.\n"
-                        f"Install a scanner or update your configuration.\n"
-                        f"{'='*70}\n"
+                    # No scanner found - warn (allow operation to continue)
+                    default_scanner = engines_list[0] if engines_list else "gitleaks"
+                    warning_msg = (
+                        f"⚠️  WARNING: Default scanner not installed\n\n"
+                        f"Please install the {default_scanner}, with the command:\n"
+                        f"  ai-guardian scanner install {default_scanner}\n\n"
+                        f"Until the scanner is not installed, you may leak secrets."
                     )
-                    logging.error(f"Scanner engine selection failed: {e}")
-                    return True, error_msg
+                    logging.warning(f"Scanner engine selection failed: {e}")
+                    return False, warning_msg
                 except Exception as e:
                     logging.error(f"Unexpected error selecting scanner engine: {e}")
                     return False, None
@@ -2428,6 +2405,11 @@ def process_hook_input():
                 ignore_files=ignore_files,
                 ignore_tools=ignore_tools
             )
+
+            if not has_secrets and error_message:
+                # Scanner not available - display warning but allow operation
+                return format_response(ide_type, has_secrets=False, hook_event=hook_event,
+                                     warning_message=error_message)
 
             if has_secrets:
                 # Check if redaction is enabled
@@ -2879,6 +2861,10 @@ def process_hook_input():
                 ignore_files=ignore_files,
                 ignore_tools=ignore_tools
             )
+
+            if not has_secrets and error_message:
+                # Scanner not available - add warning to messages list
+                warning_messages.append(error_message)
 
             if has_secrets:
                 # Secrets found - block operation

--- a/tests/integration/test_scanner_engine_integration.py
+++ b/tests/integration/test_scanner_engine_integration.py
@@ -22,8 +22,8 @@ class TestScannerEngineIntegration(unittest.TestCase):
     @patch('ai_guardian.HAS_SCANNER_ENGINE', True)
     @patch('ai_guardian.select_engine')
     @patch('ai_guardian._load_secret_scanning_config')
-    def test_scanner_not_found_raises_error(self, mock_load_config, mock_select_engine):
-        """Test that missing scanner raises error instead of silent fallback."""
+    def test_scanner_not_found_warns(self, mock_load_config, mock_select_engine):
+        """Test that missing scanner warns instead of blocking (Issue #343)."""
         # Mock configuration with leaktk
         mock_load_config.return_value = ({"engines": ["leaktk"]}, None)
 
@@ -35,18 +35,18 @@ class TestScannerEngineIntegration(unittest.TestCase):
             "  • LeakTK: brew install leaktk/tap/leaktk"
         )
 
-        # Should return blocking error
+        # Should return warning (not blocking)
         has_secrets, error_msg = check_secrets_with_gitleaks(
             "aws_key=AKIAIOSFODNN7EXAMPLE",
             filename="test.txt"
         )
 
-        # Verify it blocks
-        self.assertTrue(has_secrets, "Should block when scanner not found")
-        self.assertIsNotNone(error_msg)
-        self.assertIn("NO SCANNER AVAILABLE", error_msg)
-        self.assertIn("Secret scanning is enabled but no scanner is available", error_msg)
-        self.assertIn("Install a scanner", error_msg)
+        # Verify it warns but does NOT block
+        self.assertFalse(has_secrets, "Should NOT block when scanner not found (Issue #343)")
+        self.assertIsNotNone(error_msg, "Warning message should be returned")
+        self.assertIn("WARNING", error_msg, "Should indicate warning")
+        self.assertIn("ai-guardian scanner install leaktk", error_msg, "Should suggest installing configured scanner")
+        self.assertIn("you may leak secrets", error_msg, "Should warn about risk")
 
     @patch('ai_guardian.HAS_SCANNER_ENGINE', True)
     @patch('ai_guardian.select_engine')

--- a/tests/unit/test_pattern_server_warnings.py
+++ b/tests/unit/test_pattern_server_warnings.py
@@ -197,8 +197,8 @@ class PatternServerWarningsTest(TestCase):
     @patch('ai_guardian.select_engine')
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_pattern_server_and_no_engines_blocks(self, mock_client_class, mock_pattern_config, mock_select_engine):
-        """Test that operation is BLOCKED when pattern server fails AND no scanner engines available"""
+    def test_pattern_server_and_no_engines_warns(self, mock_client_class, mock_pattern_config, mock_select_engine):
+        """Test that operation shows WARNING when pattern server fails AND no scanner engines available"""
         # Setup: Pattern server configured without warn_on_failure field
         pattern_config = {
             "url": "https://pattern-server.example.com"
@@ -226,11 +226,12 @@ class PatternServerWarningsTest(TestCase):
             with patch('ai_guardian.HAS_SCANNER_ENGINE', True):
                 has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: Operation should be blocked (no scanner available)
-        self.assertTrue(has_secrets, "Operation should be blocked when no scanner available")
-        self.assertIsNotNone(error_msg, "Error message should be returned")
-        self.assertIn("BLOCKED BY POLICY", error_msg, "Should indicate blocking policy")
-        self.assertIn("NO SCANNER AVAILABLE", error_msg, "Should indicate no scanner")
+        # Verify: Operation should warn but NOT block (Issue #343)
+        self.assertFalse(has_secrets, "Operation should NOT be blocked when no scanner available")
+        self.assertIsNotNone(error_msg, "Warning message should be returned")
+        self.assertIn("WARNING", error_msg, "Should indicate warning")
+        self.assertIn("ai-guardian scanner install", error_msg, "Should contain install command")
+        self.assertIn("you may leak secrets", error_msg, "Should warn about leaked secrets")
 
     @patch('ai_guardian.pattern_server.logger')
     @patch('requests.get')
@@ -432,8 +433,8 @@ class PatternServerWarningsTest(TestCase):
     @patch('ai_guardian.select_engine')
     @patch('ai_guardian._load_pattern_server_config')
     @patch('ai_guardian.PatternServerClient')
-    def test_blocking_error_message_when_no_scanner(self, mock_client_class, mock_pattern_config, mock_select_engine):
-        """Test that blocking error message contains helpful information when no scanner available"""
+    def test_warning_message_when_no_scanner(self, mock_client_class, mock_pattern_config, mock_select_engine):
+        """Test that warning message contains helpful information when no scanner available (Issue #343)"""
         # Setup: Pattern server configured
         pattern_config = {
             "url": "https://pattern-server.example.com",
@@ -458,16 +459,14 @@ class PatternServerWarningsTest(TestCase):
             with patch('ai_guardian.HAS_SCANNER_ENGINE', True):
                 has_secrets, error_msg = ai_guardian.check_secrets_with_gitleaks(content, "test.txt")
 
-        # Verify: Error message contains helpful details
-        self.assertTrue(has_secrets, "Operation should be blocked")
-        self.assertIsNotNone(error_msg, "Error message should be returned")
+        # Verify: Warning message (not blocking) with helpful details (Issue #343)
+        self.assertFalse(has_secrets, "Operation should NOT be blocked when no scanner available")
+        self.assertIsNotNone(error_msg, "Warning message should be returned")
 
-        # Check for helpful information in error message
-        self.assertIn("BLOCKED BY POLICY", error_msg, "Should indicate blocking policy")
-        self.assertIn("NO SCANNER AVAILABLE", error_msg, "Should indicate no scanner available")
-        self.assertIn("pattern-server.example.com", error_msg, "Should mention server URL")
-        self.assertIn("To fix", error_msg, "Should provide fix instructions")
-        self.assertIn("Install a scanner", error_msg, "Should mention installing scanner")
+        # Check for helpful information in warning message
+        self.assertIn("WARNING", error_msg, "Should indicate warning")
+        self.assertIn("ai-guardian scanner install", error_msg, "Should contain install command")
+        self.assertIn("you may leak secrets", error_msg, "Should warn about risk")
 
     @patch('logging.warning')
     @patch('logging.info')

--- a/tests/ux/test_user_experience_contract_scanner_warning.py
+++ b/tests/ux/test_user_experience_contract_scanner_warning.py
@@ -1,0 +1,226 @@
+"""
+User Experience Contract Tests for Scanner Not Installed Warning (Issue #343)
+
+These tests document and verify the expected user experience when ai-guardian's
+default scanner is not installed. Instead of blocking the user entirely, a
+warning is displayed at each hook invocation while allowing operations to continue.
+
+Issue #343: Display warning instead of blocking when default scanner is not installed.
+"""
+
+import json
+from io import StringIO
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import ai_guardian
+from tests.fixtures.mock_mcp_server import create_hook_data
+
+
+class ScannerNotInstalledWarningTests(TestCase):
+    """
+    Tests documenting the user experience when the default scanner is not installed.
+
+    When no scanner engine is available, ai-guardian should:
+    - Display a warning message at each hook invocation
+    - Allow the operation to continue (not block)
+    - Include the scanner name and install command in the warning
+    """
+
+    @patch('ai_guardian.select_engine')
+    @patch('ai_guardian._load_secret_scanning_config')
+    def test_pretooluse_warns_when_scanner_not_installed(self, mock_config, mock_select_engine):
+        """
+        USER EXPERIENCE: Read file with no scanner installed → WARNING shown, operation ALLOWED.
+
+        Scenario:
+        1. User has not installed any scanner (e.g., gitleaks)
+        2. User asks Claude: "Read the config file"
+        3. Claude tries to Read file
+        4. ai-guardian PreToolUse hook runs
+        5. select_engine() raises RuntimeError (no scanner found)
+
+        Expected User Experience:
+        ⚠️ Warning message shown via systemMessage
+        ✅ Operation is ALLOWED (no permissionDecision: deny)
+        🛡️ User sees: "Please install the gitleaks..."
+        """
+        mock_config.return_value = ({"engines": ["gitleaks"]}, None)
+        mock_select_engine.side_effect = RuntimeError("No secret scanner found")
+
+        import tempfile
+        import os
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write("some file content")
+            temp_path = f.name
+
+        try:
+            hook_data = create_hook_data(
+                tool_name="Read",
+                tool_input={"file_path": temp_path},
+                hook_event="PreToolUse"
+            )
+
+            with patch('sys.stdin', StringIO(json.dumps(hook_data))):
+                result = ai_guardian.process_hook_input()
+
+            assert result['exit_code'] == 0
+
+            response = json.loads(result['output'])
+
+            # CONTRACT: Operation is NOT blocked
+            assert 'hookSpecificOutput' not in response or \
+                response.get('hookSpecificOutput', {}).get('permissionDecision') != 'deny', \
+                "Must NOT deny when scanner is not installed (Issue #343)"
+
+            # CONTRACT: Warning is shown via systemMessage
+            assert 'systemMessage' in response, \
+                "Must include warning via systemMessage"
+            warning = response['systemMessage']
+            assert 'WARNING' in warning, \
+                "Warning should contain WARNING indicator"
+            assert 'ai-guardian scanner install gitleaks' in warning, \
+                "Warning should contain install command with scanner name"
+            assert 'you may leak secrets' in warning, \
+                "Warning should mention risk of leaking secrets"
+
+        finally:
+            os.unlink(temp_path)
+
+    @patch('ai_guardian.select_engine')
+    @patch('ai_guardian._load_secret_scanning_config')
+    def test_posttooluse_warns_when_scanner_not_installed(self, mock_config, mock_select_engine):
+        """
+        USER EXPERIENCE: Tool output with no scanner installed → WARNING shown, output ALLOWED.
+
+        Scenario:
+        1. User has not installed any scanner
+        2. Claude runs a Bash command that produces output
+        3. ai-guardian PostToolUse hook runs to scan output
+        4. select_engine() raises RuntimeError (no scanner found)
+
+        Expected User Experience:
+        ⚠️ Warning message shown via systemMessage
+        ✅ Tool output is ALLOWED through (not blocked)
+        """
+        mock_config.return_value = ({"engines": ["gitleaks"]}, None)
+        mock_select_engine.side_effect = RuntimeError("No secret scanner found")
+
+        hook_data = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_response": {"stdout": "some command output", "stderr": ""},
+        }
+
+        with patch('sys.stdin', StringIO(json.dumps(hook_data))):
+            result = ai_guardian.process_hook_input()
+
+        assert result['exit_code'] == 0
+
+        response = json.loads(result['output'])
+
+        # CONTRACT: Operation is NOT blocked
+        assert response.get('decision') != 'block', \
+            "Must NOT block PostToolUse when scanner is not installed"
+
+        # CONTRACT: Warning is shown via systemMessage
+        assert 'systemMessage' in response, \
+            "Must include warning via systemMessage for PostToolUse"
+        warning = response['systemMessage']
+        assert 'ai-guardian scanner install gitleaks' in warning, \
+            "Warning should contain install command"
+        assert 'you may leak secrets' in warning, \
+            "Warning should mention risk"
+
+    @patch('ai_guardian.select_engine')
+    @patch('ai_guardian._load_secret_scanning_config')
+    def test_prompt_warns_when_scanner_not_installed(self, mock_config, mock_select_engine):
+        """
+        USER EXPERIENCE: User prompt with no scanner installed → WARNING shown, prompt ALLOWED.
+
+        Scenario:
+        1. User has not installed any scanner
+        2. User submits a prompt
+        3. ai-guardian UserPromptSubmit hook runs
+        4. select_engine() raises RuntimeError
+
+        Expected User Experience:
+        ⚠️ Warning message shown via systemMessage
+        ✅ Prompt submission is ALLOWED
+        """
+        mock_config.return_value = ({"engines": ["gitleaks"]}, None)
+        mock_select_engine.side_effect = RuntimeError("No secret scanner found")
+
+        hook_data = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "Please read the database config",
+        }
+
+        with patch('sys.stdin', StringIO(json.dumps(hook_data))):
+            result = ai_guardian.process_hook_input()
+
+        assert result['exit_code'] == 0
+
+        response = json.loads(result['output'])
+
+        # CONTRACT: Prompt is NOT blocked
+        assert response.get('decision') != 'block', \
+            "Must NOT block prompt when scanner is not installed"
+
+        # CONTRACT: Warning is shown via systemMessage
+        assert 'systemMessage' in response, \
+            "Must include warning via systemMessage for UserPromptSubmit"
+        warning = response['systemMessage']
+        assert 'ai-guardian scanner install gitleaks' in warning, \
+            "Warning should contain install command"
+        assert 'you may leak secrets' in warning, \
+            "Warning should mention risk"
+
+    @patch('ai_guardian.select_engine')
+    @patch('ai_guardian._load_secret_scanning_config')
+    def test_warning_uses_configured_scanner_name(self, mock_config, mock_select_engine):
+        """
+        USER EXPERIENCE: Warning dynamically uses the configured default scanner name.
+
+        When config has engines: ["betterleaks", "gitleaks"], the warning should
+        suggest installing "betterleaks" (the first/default engine), not "gitleaks".
+        """
+        mock_config.return_value = ({"engines": ["betterleaks", "gitleaks"]}, None)
+        mock_select_engine.side_effect = RuntimeError("No secret scanner found")
+
+        hook_data = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt",
+        }
+
+        with patch('sys.stdin', StringIO(json.dumps(hook_data))):
+            result = ai_guardian.process_hook_input()
+
+        response = json.loads(result['output'])
+        warning = response.get('systemMessage', '')
+
+        assert 'ai-guardian scanner install betterleaks' in warning, \
+            "Warning should suggest the configured default scanner (betterleaks), not hardcoded gitleaks"
+
+    @patch('ai_guardian.select_engine')
+    @patch('ai_guardian._load_secret_scanning_config')
+    def test_warning_defaults_to_gitleaks_when_no_config(self, mock_config, mock_select_engine):
+        """
+        USER EXPERIENCE: Warning defaults to gitleaks when no scanner config exists.
+        """
+        mock_config.return_value = (None, None)
+        mock_select_engine.side_effect = RuntimeError("No secret scanner found")
+
+        hook_data = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "test prompt",
+        }
+
+        with patch('sys.stdin', StringIO(json.dumps(hook_data))):
+            result = ai_guardian.process_hook_input()
+
+        response = json.loads(result['output'])
+        warning = response.get('systemMessage', '')
+
+        assert 'ai-guardian scanner install gitleaks' in warning, \
+            "Warning should default to gitleaks when no config exists"


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://redhat.atlassian.net//browse/itdove/ai-guardian#343>
<!-- This PR does not need a corresponding Jira item. -->

## Description
itdove/ai-guardian#343: Display warning instead of blocking when default scanner is not installed

Assisted-by: Claude

<!-- If you use any AI tool then provide that information here. The code assistant that you used, elaborating on how it was used.  -->
Assisted-by: <name of code assistant>

## Testing
<!-- Describe the testing process in a set of steps, including any relevant configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Deployment considerations
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, configuration, etc that need to be considered or prepared ahead of a deployment to a long-lived environment. Include links to any related PRs, Jiras, etc. -->
- [ ] This code change is ready for deployment on its own
- [ ] This code change requires the following considerations before being deployed:
